### PR TITLE
Add LIMIT X,Y syntax support to parser

### DIFF
--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -264,11 +264,23 @@ class MindsDBParser(Parser):
     @_('select OFFSET constant')
     def select(self, p):
         select = p.select
+        if select.offset is not None:
+            raise ParsingException(f'OFFSET already specified for this query')
         ensure_select_keyword_order(select, 'OFFSET')
         if not isinstance(p.constant.value, int):
             raise ParsingException(f'OFFSET must be an integer value, got: {p.constant.value}')
 
         select.offset = p.constant
+        return select
+
+    @_('select LIMIT constant COMMA constant')
+    def select(self, p):
+        select = p.select
+        ensure_select_keyword_order(select, 'LIMIT')
+        if not isinstance(p.constant0.value, int) or not isinstance(p.constant1.value, int):
+            raise ParsingException(f'LIMIT must have integer arguments, got: {p.constant0.value}, {p.constant1.value}')
+        select.offset = p.constant0
+        select.limit = p.constant1
         return select
 
     @_('select LIMIT constant')

--- a/mindsdb_sql/parser/dialects/mysql/parser.py
+++ b/mindsdb_sql/parser/dialects/mysql/parser.py
@@ -165,6 +165,8 @@ class MySQLParser(SQLParser):
     @_('select OFFSET constant')
     def select(self, p):
         select = p.select
+        if select.offset is not None:
+            raise ParsingException(f'OFFSET already specified for this query')
         ensure_select_keyword_order(select, 'OFFSET')
         if not isinstance(p.constant.value, int):
             raise ParsingException(f'OFFSET must be an integer value, got: {p.constant.value}')
@@ -179,6 +181,16 @@ class MySQLParser(SQLParser):
         if not isinstance(p.constant.value, int):
             raise ParsingException(f'LIMIT must be an integer value, got: {p.constant.value}')
         select.limit = p.constant
+        return select
+
+    @_('select LIMIT constant COMMA constant')
+    def select(self, p):
+        select = p.select
+        ensure_select_keyword_order(select, 'LIMIT')
+        if not isinstance(p.constant0.value, int) or not isinstance(p.constant1.value, int):
+            raise ParsingException(f'LIMIT must have integer arguments, got: {p.constant0.value}, {p.constant1.value}')
+        select.offset = p.constant0
+        select.limit = p.constant1
         return select
 
     @_('select ORDER_BY ordering_terms')

--- a/mindsdb_sql/parser/parser.py
+++ b/mindsdb_sql/parser/parser.py
@@ -165,6 +165,8 @@ class SQLParser(Parser):
     @_('select OFFSET constant')
     def select(self, p):
         select = p.select
+        if select.offset is not None:
+            raise ParsingException(f'OFFSET already specified for this query')
         ensure_select_keyword_order(select, 'OFFSET')
         if not isinstance(p.constant.value, int):
             raise ParsingException(f'OFFSET must be an integer value, got: {p.constant.value}')
@@ -179,6 +181,16 @@ class SQLParser(Parser):
         if not isinstance(p.constant.value, int):
             raise ParsingException(f'LIMIT must be an integer value, got: {p.constant.value}')
         select.limit = p.constant
+        return select
+
+    @_('select LIMIT constant COMMA constant')
+    def select(self, p):
+        select = p.select
+        ensure_select_keyword_order(select, 'LIMIT')
+        if not isinstance(p.constant0.value, int) or not isinstance(p.constant1.value, int):
+            raise ParsingException(f'LIMIT must have integer arguments, got: {p.constant0.value}, {p.constant1.value}')
+        select.offset = p.constant0
+        select.limit = p.constant1
         return select
 
     @_('select ORDER_BY ordering_terms')

--- a/tests/test_parser/test_base_sql/test_select_structure.py
+++ b/tests/test_parser/test_base_sql/test_select_structure.py
@@ -370,6 +370,22 @@ class TestSelectStructure:
         assert ast.to_tree() == expected_ast.to_tree()
         assert str(ast) == str(expected_ast)
 
+    def test_select_limit_two_arguments(self, dialect):
+        sql = """SELECT * FROM t1 LIMIT 2, 1"""
+        ast = parse_sql(sql, dialect=dialect)
+        expected_ast = Select(targets=[Star()],
+                                                   from_table=Identifier(parts=['t1']),
+                                                   limit=Constant(1),
+                                                   offset=Constant(2))
+
+        assert ast.to_tree() == expected_ast.to_tree()
+        assert str(ast) == str(expected_ast)
+
+    def test_select_limit_two_arguments_and_offset_error(self, dialect):
+        sql = """SELECT * FROM t1 LIMIT 2, 1 OFFSET 2"""
+        with pytest.raises(ParsingException):
+            parse_sql(sql, dialect=dialect)
+
     def test_having_raises_duplicate(self, dialect):
         sql = f'SELECT column FROM tab GROUP BY col HAVING col > 1 HAVING col > 1'
         with pytest.raises(ParsingException):


### PR DESCRIPTION
Resolves https://github.com/mindsdb/mindsdb_sql/issues/79