### PR TITLE
Simplify create predictor syntax

### DIFF
--- a/mindsdb_sql/__about__.py
+++ b/mindsdb_sql/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'mindsdb_sql'
 __package_name__ = 'mindsdb_sql'
-__version__ = '0.0.36'
+__version__ = '0.0.37'
 __description__ = "Pure python SQL parser"
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb_sql/parser/dialects/mindsdb/create_integration.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/create_integration.py
@@ -29,5 +29,5 @@ class CreateIntegration(ASTNode):
         return out_str
 
     def get_string(self, *args, **kwargs):
-        out_str = f'CREATE INTEGRATION {str(self.name)} WITH ENGINE = {repr(self.engine)}, PARAMETERS = \'{json.dumps(self.parameters)}\''
+        out_str = f'CREATE INTEGRATION {str(self.name)} WITH ENGINE = {repr(self.engine)}, PARAMETERS = {json.dumps(self.parameters)}'
         return out_str

--- a/mindsdb_sql/parser/dialects/mindsdb/create_predictor.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/create_predictor.py
@@ -74,8 +74,8 @@ class CreatePredictor(ASTNode):
         group_by_str = f'GROUP BY {", ".join([out.to_string() for out in self.group_by])} ' if self.group_by else ''
         window_str = f'WINDOW {self.window} ' if self.window is not None else ''
         horizon_str = f'HORIZON {self.horizon} ' if self.horizon is not None else ''
-        using_str = f'USING \'{json.dumps(self.using)}\'' if self.using is not None else ''
-        out_str = f'CREATE PREDICTOR {self.name.to_string()} FROM {self.integration_name.to_string()} WITH ({repr(self.query)}) AS {self.datasource_name.to_string()} ' \
+        using_str = f'USING {json.dumps(self.using)}' if self.using is not None else ''
+        out_str = f'CREATE PREDICTOR {self.name.to_string()} FROM {self.integration_name.to_string()} WITH {repr(self.query)} AS {self.datasource_name.to_string()} ' \
                   f'PREDICT {targets_str} ' \
                   f'{order_by_str}' \
                   f'{group_by_str}' \

--- a/mindsdb_sql/parser/dialects/mindsdb/create_predictor.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/create_predictor.py
@@ -8,8 +8,8 @@ class CreatePredictor(ASTNode):
                  name,
                  integration_name,
                  query,
-                 datasource_name,
                  targets,
+                 datasource_name=None,
                  order_by=None,
                  group_by=None,
                  window=None,
@@ -20,8 +20,8 @@ class CreatePredictor(ASTNode):
         self.name = name
         self.integration_name = integration_name
         self.query = query
-        self.datasource_name = datasource_name
         self.targets = targets
+        self.datasource_name = datasource_name
         self.order_by = order_by
         self.group_by = group_by
         self.window = window
@@ -35,7 +35,10 @@ class CreatePredictor(ASTNode):
         name_str = f'\n{ind1}name={self.name.to_tree()},'
         integration_name_str = f'\n{ind1}integration_name={self.integration_name.to_tree()},'
         query_str = f'\n{ind1}query={repr(self.query)},'
-        datasource_name_str = f'\n{ind1}datasource_name={self.datasource_name.to_tree()},'
+
+        datasource_name_str = ''
+        if self.datasource_name:
+            datasource_name_str = f'\n{ind1}datasource_name={self.datasource_name.to_tree()},'
 
         target_trees = ',\n'.join([t.to_tree(level=level+2) for t in self.targets])
         targets_str = f'\n{ind1}targets=[\n{target_trees}\n{ind1}],'
@@ -75,7 +78,10 @@ class CreatePredictor(ASTNode):
         window_str = f'WINDOW {self.window} ' if self.window is not None else ''
         horizon_str = f'HORIZON {self.horizon} ' if self.horizon is not None else ''
         using_str = f'USING {json.dumps(self.using)}' if self.using is not None else ''
-        out_str = f'CREATE PREDICTOR {self.name.to_string()} FROM {self.integration_name.to_string()} WITH {repr(self.query)} AS {self.datasource_name.to_string()} ' \
+        datasource_name_str = f' AS {self.datasource_name.to_string()} ' if self.datasource_name is not None else ''
+
+        out_str = f'CREATE PREDICTOR {self.name.to_string()} FROM {self.integration_name.to_string()} WITH {repr(self.query)}' \
+                  f'{datasource_name_str}' \
                   f'PREDICT {targets_str} ' \
                   f'{order_by_str}' \
                   f'{group_by_str}' \

--- a/mindsdb_sql/parser/dialects/mindsdb/lexer.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/lexer.py
@@ -1,3 +1,4 @@
+import json
 import re
 from sly import Lexer
 
@@ -49,7 +50,11 @@ class MindsDBLexer(Lexer):
         IN, LIKE, CONCAT, BETWEEN, WINDOW,
 
         # Data types
-        CAST, ID, INTEGER, FLOAT, STRING, NULL, TRUE, FALSE}
+        CAST, ID, INTEGER, FLOAT, STRING, NULL, TRUE, FALSE,
+
+        JSON,
+
+    }
 
     RETRAIN = r'\bRETRAIN\b'
     # Custom commands
@@ -190,6 +195,11 @@ class MindsDBLexer(Lexer):
     @_(r'\d+')
     def INTEGER(self, t):
         t.value = int(t.value)
+        return t
+
+    @_(r'\{[a-zA-Z0-9\"\':,\{\}\[\]\s]*\}')
+    def JSON(self, t):
+        t.value = json.loads(t.value)
         return t
 
     @_(r'"[^"]*"',

--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -214,15 +214,23 @@ class MindsDBParser(Parser):
         p.create_predictor.order_by = p.ordering_terms
         return p.create_predictor
 
-    @_('CREATE PREDICTOR identifier FROM identifier WITH STRING AS identifier PREDICT result_columns')
+    @_('CREATE PREDICTOR identifier FROM identifier WITH STRING optional_data_source_name PREDICT result_columns')
     def create_predictor(self, p):
         return CreatePredictor(
             name=p.identifier0,
             integration_name=p.identifier1,
             query=p.STRING,
-            datasource_name=p.identifier2,
-            targets=p.result_columns
+            datasource_name=p.optional_data_source_name,
+            targets=p.result_columns,
         )
+
+    @_('AS identifier')
+    def optional_data_source_name(self, p):
+        return p.identifier
+
+    @_('empty')
+    def optional_data_source_name(self, p):
+        pass
 
     # CREATE INTEGRATION
     @_('CREATE INTEGRATION ID WITH ENGINE EQUALS STRING COMMA PARAMETERS EQUALS JSON',

--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -185,14 +185,10 @@ class MindsDBParser(Parser):
         return DropIntegration(p.identifier)
 
     # CREATE PREDICTOR
-    @_('create_predictor USING STRING')
+    @_('create_predictor USING JSON')
     def create_predictor(self, p):
-        try:
-            using = json.loads(p.STRING)
-            p.create_predictor.using = using
-            return p.create_predictor
-        except ValueError as err:
-            raise ParsingException(f'Predictor USING must be a valid json, got error: {str(err)}')
+        p.create_predictor.using = p.JSON
+        return p.create_predictor
 
     @_('create_predictor HORIZON INTEGER')
     def create_predictor(self, p):
@@ -218,7 +214,7 @@ class MindsDBParser(Parser):
         p.create_predictor.order_by = p.ordering_terms
         return p.create_predictor
 
-    @_('CREATE PREDICTOR identifier FROM identifier WITH LPAREN STRING RPAREN AS identifier PREDICT result_columns')
+    @_('CREATE PREDICTOR identifier FROM identifier WITH STRING AS identifier PREDICT result_columns')
     def create_predictor(self, p):
         return CreatePredictor(
             name=p.identifier0,
@@ -229,17 +225,12 @@ class MindsDBParser(Parser):
         )
 
     # CREATE INTEGRATION
-    @_('CREATE INTEGRATION ID WITH ENGINE EQUALS STRING COMMA PARAMETERS EQUALS STRING',
-       'CREATE DATASOURCE ID WITH ENGINE EQUALS STRING COMMA PARAMETERS EQUALS STRING')
+    @_('CREATE INTEGRATION ID WITH ENGINE EQUALS STRING COMMA PARAMETERS EQUALS JSON',
+       'CREATE DATASOURCE ID WITH ENGINE EQUALS STRING COMMA PARAMETERS EQUALS JSON')
     def create_integration(self, p):
-        try:
-            parameters = json.loads(p.STRING1)
-            return CreateIntegration(name=p.ID,
-                                     engine=p.STRING0,
-                                     parameters=parameters)
-        except ValueError as err:
-            raise ParsingException(f'Integration args must be a valid json, got error: {str(err)}')
-
+        return CreateIntegration(name=p.ID,
+                                 engine=p.STRING,
+                                 parameters=p.JSON)
 
     # UNION / UNION ALL
     @_('select UNION select')

--- a/tests/test_parser/test_mindsdb/test_create_integration.py
+++ b/tests/test_parser/test_mindsdb/test_create_integration.py
@@ -7,7 +7,7 @@ from mindsdb_sql.parser.ast import *
 
 class TestCreateIntegration:
     def test_create_integration_lexer(self):
-        sql = "CREATE INTEGRATION db WITH ENGINE = 'mysql', PARAMETERS = '{\"user\": \"admin\", \"password\": \"admin\"}'"
+        sql = "CREATE INTEGRATION db WITH ENGINE = 'mysql', PARAMETERS = {\"user\": \"admin\", \"password\": \"admin\"}"
         tokens = list(MindsDBLexer().tokenize(sql))
         assert tokens[0].type == 'CREATE'
         assert tokens[1].type == 'INTEGRATION'
@@ -19,10 +19,10 @@ class TestCreateIntegration:
         assert tokens[7].type == 'COMMA'
         assert tokens[8].type == 'PARAMETERS'
         assert tokens[9].type == 'EQUALS'
-        assert tokens[10].type == 'STRING'
+        assert tokens[10].type == 'JSON'
 
     def test_create_integration_ok(self):
-        sql = "CREATE INTEGRATION db WITH ENGINE = 'mysql', PARAMETERS = '{\"user\": \"admin\", \"password\": \"admin\"}'"
+        sql = "CREATE INTEGRATION db WITH ENGINE = 'mysql', PARAMETERS = {\"user\": \"admin\", \"password\": \"admin\"}"
         ast = parse_sql(sql, dialect='mindsdb')
         expected_ast = CreateIntegration(name='db',
                                   engine='mysql',
@@ -32,7 +32,7 @@ class TestCreateIntegration:
         assert ast.to_tree() == expected_ast.to_tree()
 
     def test_create_datasource_ok(self):
-        sql = "CREATE DATASOURCE db WITH ENGINE = 'mysql', PARAMETERS = '{\"user\": \"admin\", \"password\": \"admin\"}'"
+        sql = "CREATE DATASOURCE db WITH ENGINE = 'mysql', PARAMETERS = {\"user\": \"admin\", \"password\": \"admin\"}"
         ast = parse_sql(sql, dialect='mindsdb')
         expected_ast = CreateIntegration(name='db',
                                   engine='mysql',

--- a/tests/test_parser/test_mindsdb/test_create_predictor.py
+++ b/tests/test_parser/test_mindsdb/test_create_predictor.py
@@ -10,14 +10,15 @@ class TestCreatePredictor:
     def test_create_predictor_full(self):
         sql = """CREATE PREDICTOR pred
                 FROM integration_name 
-                WITH ('select * FROM table') 
+                WITH 'select * FROM table'
                 AS ds_name
                 PREDICT f1 as f1_alias, f2
                 ORDER BY f_order_1 ASC, f_order_2, f_order_3 DESC
                 GROUP BY f_group_1, f_group_2
                 WINDOW 100
                 HORIZON 7
-                USING '{"x": 1, "y": "a"}'"""
+                USING {"x": 1, "y": "a"}
+                """
         ast = parse_sql(sql, dialect='mindsdb')
         expected_ast = CreatePredictor(
             name=Identifier('pred'),
@@ -42,7 +43,7 @@ class TestCreatePredictor:
     def test_create_predictor_minimal(self):
         sql = """CREATE PREDICTOR pred
                 FROM integration_name 
-                WITH ('select * FROM table') 
+                WITH 'select * FROM table'
                 AS ds_name
                 PREDICT f1 as f1_alias, f2
                 """
@@ -62,7 +63,7 @@ class TestCreatePredictor:
     def test_create_predictor_quotes(self):
         sql = """CREATE PREDICTOR xxx 
                  FROM `yyy` 
-                  WITH ('SELECT * FROM zzz') 
+                  WITH 'SELECT * FROM zzz'
                   AS x 
                   PREDICT sss
                 """
@@ -80,7 +81,7 @@ class TestCreatePredictor:
     def test_create_predictor_invalid_json(self):
         sql = """CREATE PREDICTOR pred
                 FROM integration_name 
-                WITH ('select * FROM table') 
+                WITH 'select * FROM table'
                 AS ds_name
                 PREDICT f1 as f1_alias, f2
                 ORDER BY f_order_1 ASC, f_order_2, f_order_3 DESC


### PR DESCRIPTION
Resolves #100 

Now the syntax looks like this:
```
CREATE PREDICTOR pred
                FROM integration_name 
                WITH 'select * FROM table'
                AS ds_name
                PREDICT f1 as f1_alias, f2
                ORDER BY f_order_1 ASC, f_order_2, f_order_3 DESC
                GROUP BY f_group_1, f_group_2
                WINDOW 100
                HORIZON 7
                USING {"x": 1, "y": "a"}
```
Notice: no commas around JSON.

Create integration also changed to have no commas around JSON:
```
CREATE INTEGRATION db WITH ENGINE = 'mysql', PARAMETERS = {\"user\": \"admin\", \"password\": \"admin\"}
```