### PR TITLE
Insert command

### DIFF
--- a/mindsdb_sql/parser/ast/__init__.py
+++ b/mindsdb_sql/parser/ast/__init__.py
@@ -9,3 +9,4 @@ from .rollback_transaction import *
 from .commit_transaction import *
 from .explain import *
 from .alter_table import *
+from .insert import *

--- a/mindsdb_sql/parser/ast/insert.py
+++ b/mindsdb_sql/parser/ast/insert.py
@@ -1,0 +1,72 @@
+from mindsdb_sql.parser.ast.base import ASTNode
+from mindsdb_sql.utils import indent
+
+
+class Insert(ASTNode):
+    def __init__(self,
+                 table,
+                 columns=None,
+                 values=None,
+                 from_select=None,
+                 *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.table = table
+        self.columns = columns
+
+        # TODO require one of [values, from_select] is set
+        self.values = values
+        self.from_select = from_select
+
+    def to_tree(self, *args, level=0, **kwargs):
+        ind = indent(level)
+        ind1 = indent(level + 1)
+        ind2 = indent(level + 2)
+        if self.columns is not None:
+            columns_str = ', '.join([i.to_tree() for i in self.columns])
+        else:
+            columns_str = ''
+
+        if self.values is not None:
+            values = []
+            for row in self.values:
+                row_str = f'\n'.join([i.to_tree(level=level+3) for i in row])
+                values.append(f'{ind2}[\n{row_str}\n{ind2}],\n')
+            values_str = ''.join(values)
+            values_str = f'{ind1}values=[\n{values_str}{ind1}]\n'
+        else:
+            values_str = ''
+
+        if self.from_select is not None:
+            from_select_str = f'{ind1}from_select=\n{self.from_select.to_tree(level=level+2)}\n'
+        else:
+            from_select_str = ''
+
+        out_str = f'{ind}Insert(table={self.table.to_tree()}\n' \
+                  f'{ind1}columns=[{columns_str}]\n' \
+                  f'{values_str}' \
+                  f'{from_select_str}' \
+                  f'{ind})\n'
+        return out_str
+
+    def get_string(self, *args, **kwargs):
+        if self.columns is not None:
+            cols = ', '.join(map(str, self.columns))
+            columns_str = f'({cols})'
+        else:
+            columns_str = ''
+
+        if self.values is not None:
+            values = []
+            for row in self.values:
+                row_str = ', '.join(map(str, row))
+                values.append(f'({row_str})')
+            values_str = 'VALUES ' + ', '.join(values)
+        else:
+            values_str = ''
+
+        if self.from_select is not None:
+            from_select_str = self.from_select
+        else:
+            from_select_str = ''
+
+        return f'INSERT INTO {str(self.table)}{columns_str} {values_str}{from_select_str}'

--- a/mindsdb_sql/parser/dialects/mindsdb/lexer.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/lexer.py
@@ -47,6 +47,9 @@ class MindsDBLexer(Lexer):
 
         UNION, ALL,
 
+        # DML
+        INSERT, INTO, VALUES,
+
         # Special
         DOT, COMMA, LPAREN, RPAREN, PARAMETER,
 
@@ -157,6 +160,11 @@ class MindsDBLexer(Lexer):
 
     UNION = r'\bUNION\b'
     ALL = r'\bALL\b'
+
+    # DML
+    INSERT = r'\bINSERT\b'
+    INTO = r'\bINTO\b'
+    VALUES = r'\bVALUES\b'
 
     # Special
     DOT = r'\.'

--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -46,6 +46,7 @@ class MindsDBParser(Parser):
        'drop_integration',
        'union',
        'select',
+       'insert',
        )
     def query(self, p):
         return p[0]
@@ -145,6 +146,27 @@ class MindsDBParser(Parser):
        'ALL')
     def show_category(self, p):
         return ' '.join([x for x in p])
+
+    # INSERT
+    @_('INSERT INTO from_table LPAREN result_columns RPAREN select')
+    @_('INSERT INTO from_table select')
+    def insert(self, p):
+        columns = getattr(p, 'result_columns', None)
+        return Insert(table=p.from_table, columns=columns, from_select=p.select)
+
+    @_('INSERT INTO from_table LPAREN result_columns RPAREN VALUES expr_list_set')
+    @_('INSERT INTO from_table VALUES expr_list_set')
+    def insert(self, p):
+        columns = getattr(p, 'result_columns', None)
+        return Insert(table=p.from_table, columns=columns, values=p.expr_list_set)
+
+    @_('expr_list_set COMMA expr_list_set')
+    def expr_list_set(self, p):
+        return p.expr_list_set0 + p.expr_list_set1
+
+    @_('LPAREN expr_list RPAREN')
+    def expr_list_set(self, p):
+        return [p.expr_list]
 
     # DESCRIBE
 

--- a/mindsdb_sql/parser/dialects/mysql/parser.py
+++ b/mindsdb_sql/parser/dialects/mysql/parser.py
@@ -33,6 +33,7 @@ class MySQLParser(SQLParser):
        'describe',
        'union',
        'select',
+       'insert',
        )
     def query(self, p):
         return p[0]
@@ -130,6 +131,27 @@ class MySQLParser(SQLParser):
        'STATUS')
     def show_category(self, p):
         return ' '.join([x for x in p])
+
+    # INSERT
+    @_('INSERT INTO from_table LPAREN result_columns RPAREN select')
+    @_('INSERT INTO from_table select')
+    def insert(self, p):
+        columns = getattr(p, 'result_columns', None)
+        return Insert(table=p.from_table, columns=columns, from_select=p.select)
+
+    @_('INSERT INTO from_table LPAREN result_columns RPAREN VALUES expr_list_set')
+    @_('INSERT INTO from_table VALUES expr_list_set')
+    def insert(self, p):
+        columns = getattr(p, 'result_columns', None)
+        return Insert(table=p.from_table, columns=columns, values=p.expr_list_set)
+
+    @_('expr_list_set COMMA expr_list_set')
+    def expr_list_set(self, p):
+        return p.expr_list_set0 + p.expr_list_set1
+
+    @_('LPAREN expr_list RPAREN')
+    def expr_list_set(self, p):
+        return [p.expr_list]
 
     # DESCRIBE
 

--- a/mindsdb_sql/parser/lexer.py
+++ b/mindsdb_sql/parser/lexer.py
@@ -30,6 +30,9 @@ class SQLLexer(Lexer):
 
         UNION, ALL,
 
+        # DML
+        INSERT, INTO, VALUES,
+
         # Special
         DOT, COMMA, LPAREN, RPAREN, PARAMETER,
 
@@ -109,6 +112,11 @@ class SQLLexer(Lexer):
 
     UNION = r'\bUNION\b'
     ALL = r'\bALL\b'
+
+    # DML
+    INSERT = r'\bINSERT\b'
+    INTO = r'\bINTO\b'
+    VALUES = r'\bVALUES\b'
 
     # Special
     DOT = r'\.'

--- a/mindsdb_sql/parser/parser.py
+++ b/mindsdb_sql/parser/parser.py
@@ -30,6 +30,7 @@ class SQLParser(Parser):
        'describe',
        'union',
        'select',
+       'insert',
        )
     def query(self, p):
         return p[0]
@@ -119,6 +120,27 @@ class SQLParser(Parser):
        'STATUS')
     def show_category(self, p):
         return ' '.join([x for x in p])
+
+    # INSERT
+    @_('INSERT INTO from_table LPAREN result_columns RPAREN select')
+    @_('INSERT INTO from_table select')
+    def insert(self, p):
+        columns = getattr(p, 'result_columns', None)
+        return Insert(table=p.from_table, columns=columns, from_select=p.select)
+
+    @_('INSERT INTO from_table LPAREN result_columns RPAREN VALUES expr_list_set')
+    @_('INSERT INTO from_table VALUES expr_list_set')
+    def insert(self, p):
+        columns = getattr(p, 'result_columns', None)
+        return Insert(table=p.from_table, columns=columns, values=p.expr_list_set)
+
+    @_('expr_list_set COMMA expr_list_set')
+    def expr_list_set(self, p):
+        return p.expr_list_set0 + p.expr_list_set1
+
+    @_('LPAREN expr_list RPAREN')
+    def expr_list_set(self, p):
+        return [p.expr_list]
 
     # DESCRIBE
 

--- a/tests/test_parser/test_base_sql/test_insert.py
+++ b/tests/test_parser/test_base_sql/test_insert.py
@@ -1,0 +1,76 @@
+import pytest
+
+from mindsdb_sql import parse_sql
+from mindsdb_sql.parser.ast import *
+
+
+@pytest.mark.parametrize('dialect', ['sqlite', 'mysql', 'mindsdb'])
+class TestDDL:
+
+    def test_insert(self, dialect):
+        sql = "INSERT INTO tbl_name(a, c) VALUES (1, 3), (4, 5)"
+
+        ast = parse_sql(sql, dialect=dialect)
+        expected_ast = Insert(
+            table=Identifier('tbl_name'),
+            columns=[Identifier('a'), Identifier('c')],
+            values=[
+                [Constant(1), Constant(3)],
+                [Constant(4), Constant(5)],
+            ]
+        )
+
+        assert str(ast).lower() == sql.lower()
+        assert ast.to_tree() == expected_ast.to_tree()
+
+    def test_insert_no_columns(self, dialect):
+        sql = "INSERT INTO tbl_name VALUES (1, 3), (4, 5)"
+
+        ast = parse_sql(sql, dialect=dialect)
+        expected_ast = Insert(
+            table=Identifier('tbl_name'),
+            values=[
+                [Constant(1), Constant(3)],
+                [Constant(4), Constant(5)],
+            ]
+        )
+
+        assert str(ast).lower() == sql.lower()
+        assert ast.to_tree() == expected_ast.to_tree()
+
+    def test_insert_from_select(self, dialect):
+        sql = "INSERT INTO tbl_name(a, c) SELECT b, d from table2"
+
+        ast = parse_sql(sql, dialect=dialect)
+        expected_ast = Insert(
+            table=Identifier('tbl_name'),
+            columns=[Identifier('a'), Identifier('c')],
+            from_select=Select(
+                targets=[
+                    Identifier('b'),
+                    Identifier('d'),
+                ],
+                from_table=Identifier('table2')
+            )
+        )
+
+        assert str(ast).lower() == sql.lower()
+        assert ast.to_tree() == expected_ast.to_tree()
+
+    def test_insert_from_select_no_columns(self, dialect):
+        sql = "INSERT INTO tbl_name SELECT b, d from table2"
+
+        ast = parse_sql(sql, dialect=dialect)
+        expected_ast = Insert(
+            table=Identifier('tbl_name'),
+            from_select=Select(
+                targets=[
+                    Identifier('b'),
+                    Identifier('d'),
+                ],
+                from_table=Identifier('table2')
+            )
+        )
+
+        assert str(ast).lower() == sql.lower()
+        assert ast.to_tree() == expected_ast.to_tree()


### PR DESCRIPTION
#122 

Supported syntax for 3 dialects (sqlite, mysql, mindsdb):
- insert into table [(col,..)] values (expresion,..)[, (..)]
- insert into table [(col,..)] select_statement

#54
```
INSERT INTO mindsdb.predictor (name, predict, select_data_query, training_options) 
VALUES
            (
                'name',
                'f1 as f1_alias, f2',
                'select * FROM table',
                '{{"join_learn_process": true, "stop_training_in_x_seconds": 3}}'
            )
```
is parsed as:
```
Insert(table=Identifier(parts=['mindsdb', 'predictor'])
  columns=[Identifier(parts=['name']), Identifier(parts=['predict']), Identifier(parts=['select_data_query']), Identifier(parts=['training_options'])]
  values=[
    [
      Constant(value='name')
      Constant(value='f1 as f1_alias, f2')
      Constant(value='select * FROM table')
      Constant(value='{{"join_learn_process": true, "stop_training_in_x_seconds": 3}}')
    ],
  ]
)
```