### PR TITLE
Advanced support of 'SET' statement

### DIFF
--- a/mindsdb_sql/parser/ast/select/__init__.py
+++ b/mindsdb_sql/parser/ast/select/__init__.py
@@ -1,7 +1,7 @@
 from .select import Select
 from .common_table_expression import CommonTableExpression
 from .union import Union
-from .constant import Constant, NullConstant
+from .constant import Constant, NullConstant, SpecialConstant
 from .identifier import Identifier
 from .star import Star
 from .join import Join

--- a/mindsdb_sql/parser/ast/select/constant.py
+++ b/mindsdb_sql/parser/ast/select/constant.py
@@ -30,3 +30,16 @@ class NullConstant(Constant):
 
     def get_string(self, *args, **kwargs):
         return 'NULL'
+
+
+# DEFAULT
+class SpecialConstant(ASTNode):
+    def __init__(self, name, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.name = name
+
+    def to_tree(self, *args, level=0, **kwargs):
+        return indent(level) + f'SpecialConstant(name={self.name})'
+
+    def get_string(self, *args, **kwargs):
+        return self.name

--- a/mindsdb_sql/parser/ast/set.py
+++ b/mindsdb_sql/parser/ast/set.py
@@ -1,4 +1,5 @@
 from mindsdb_sql.parser.ast.base import ASTNode
+from mindsdb_sql.parser.ast import Tuple
 from mindsdb_sql.utils import indent
 
 
@@ -8,6 +9,7 @@ class Set(ASTNode):
                  arg=None,
                  *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.category = category
         self.category = category
         self.arg = arg
 
@@ -23,6 +25,9 @@ class Set(ASTNode):
         return out_str
 
     def get_string(self, *args, **kwargs):
-        arg_str = f' {str(self.arg)}' if self.arg else ''
+        if isinstance(self.arg, Tuple):
+            arg_str = ', '.join([str(i) for i in self.arg.items])
+        else:
+            arg_str = f' {str(self.arg)}' if self.arg else ''
         return f'SET {self.category if self.category else ""}{arg_str}'
 

--- a/mindsdb_sql/parser/ast/set.py
+++ b/mindsdb_sql/parser/ast/set.py
@@ -31,3 +31,59 @@ class Set(ASTNode):
             arg_str = f' {str(self.arg)}' if self.arg else ''
         return f'SET {self.category if self.category else ""}{arg_str}'
 
+
+class SetTransaction(ASTNode):
+    def __init__(self,
+                 isolation_level=None,
+                 access_mode=None,
+                 scope=None,
+                 *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if isolation_level is not None:
+            isolation_level = isolation_level.upper()
+        if access_mode is not None:
+            access_mode = access_mode.upper()
+        if scope is not None:
+            scope = scope.upper()
+
+        self.scope = scope
+        self.access_mode = access_mode
+        self.isolation_level = isolation_level
+
+    def to_tree(self, *args, level=0, **kwargs):
+        ind = indent(level)
+        if self.scope is None:
+            scope_str = ''
+        else:
+            scope_str = f'scope={self.scope}, '
+
+        properties = []
+        if self.isolation_level is not None:
+            properties.append('ISOLATION LEVEL ' + self.isolation_level)
+        if self.access_mode is not None:
+            properties.append(self.access_mode)
+        prop_str = ', '.join(properties)
+
+        out_str = f'{ind}SetTransaction(' \
+                  f'{scope_str}' \
+                  f'properties=[{prop_str}]' \
+                  f'\n{ind})'
+        return out_str
+
+    def get_string(self, *args, **kwargs):
+        properties = []
+        if self.isolation_level is not None:
+            properties.append('ISOLATION LEVEL ' + self.isolation_level)
+        if self.access_mode is not None:
+            properties.append(self.access_mode)
+
+        prop_str = ', '.join(properties)
+
+        if self.scope is None:
+            scope_str = ''
+        else:
+            scope_str = self.scope + ' '
+
+        return f'SET {scope_str}TRANSACTION {prop_str}'
+

--- a/mindsdb_sql/parser/dialects/mindsdb/lexer.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/lexer.py
@@ -35,7 +35,7 @@ class MindsDBLexer(Lexer):
         VARIABLES, SESSION, STATUS,
         GLOBAL, PROCEDURE, FUNCTION, INDEX, WARNINGS,
         ENGINES, CHARSET, COLLATION, PLUGINS, CHARACTER,
-
+        PERSIST, PERSIST_ONLY,
 
         # SELECT Keywords
         WITH, SELECT, DISTINCT, FROM, WHERE, AS,
@@ -124,7 +124,8 @@ class MindsDBLexer(Lexer):
     CHARACTER = r'\bCHARACTER\b'
     COLLATION = r'\bCOLLATION\b'
     PLUGINS = r'\bPLUGINS\b'
-
+    PERSIST = r'\bPERSIST\b'
+    PERSIST_ONLY = r'\bPERSIST_ONLY\b'
 
     # SELECT
 

--- a/mindsdb_sql/parser/dialects/mindsdb/lexer.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/lexer.py
@@ -35,7 +35,7 @@ class MindsDBLexer(Lexer):
         VARIABLES, SESSION, STATUS,
         GLOBAL, PROCEDURE, FUNCTION, INDEX, WARNINGS,
         ENGINES, CHARSET, COLLATION, PLUGINS, CHARACTER,
-        PERSIST, PERSIST_ONLY,
+        PERSIST, PERSIST_ONLY, DEFAULT,
 
         # SELECT Keywords
         WITH, SELECT, DISTINCT, FROM, WHERE, AS,
@@ -126,6 +126,7 @@ class MindsDBLexer(Lexer):
     PLUGINS = r'\bPLUGINS\b'
     PERSIST = r'\bPERSIST\b'
     PERSIST_ONLY = r'\bPERSIST_ONLY\b'
+    DEFAULT = r'\bDEFAULT\b'
 
     # SELECT
 

--- a/mindsdb_sql/parser/dialects/mindsdb/lexer.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/lexer.py
@@ -19,6 +19,8 @@ class MindsDBLexer(Lexer):
 
         # Misc
         SET, AUTOCOMMIT, START, TRANSACTION, COMMIT, ROLLBACK, ALTER, EXPLAIN,
+        ISOLATION, LEVEL, REPEATABLE, READ, WRITE, UNCOMMITTED, COMMITTED,
+        SERIALIZABLE, ONLY,
 
         # Mindsdb special
 
@@ -100,6 +102,15 @@ class MindsDBLexer(Lexer):
     ROLLBACK = r'\bROLLBACK\b'
     EXPLAIN = r'\bEXPLAIN\b'
     ALTER = r'\bALTER\b'
+    ISOLATION = r'\bISOLATION\b'
+    LEVEL = r'\bLEVEL\b'
+    REPEATABLE = r'\bREPEATABLE\b'
+    READ = r'\bREAD\b'
+    WRITE = r'\bWRITE\b'
+    UNCOMMITTED = r'\bUNCOMMITTED\b'
+    COMMITTED = r'\bCOMMITTED\b'
+    SERIALIZABLE = r'\bSERIALIZABLE\b'
+    ONLY = r'\bONLY\b'
 
     DESCRIBE = r'\bDESCRIBE\b'
 

--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -77,10 +77,6 @@ class MindsDBParser(Parser):
 
     # Set
 
-    @_('SET AUTOCOMMIT')
-    def set(self, p):
-        return Set(category=p.AUTOCOMMIT)
-
     @_('SET expr')
     def set(self, p):
         return Set(arg=p.expr)

--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -106,6 +106,21 @@ class MindsDBParser(Parser):
     def set_modifier(self, p):
         return p[0]
 
+    @_('SET charset constant')
+    @_('SET charset DEFAULT')
+    def set(self, p):
+        if hasattr(p, 'DEFAULT'):
+            arg = SpecialConstant('DEFAULT')
+        else:
+            arg = p.constant
+        return Set(category='CHARSET', arg=arg)
+
+    @_('CHARACTER SET',
+       'CHARSET',
+       )
+    def charset(self, p):
+        return p[0]
+
     # Show
 
     @_('SHOW show_category show_condition_or_nothing')

--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -77,15 +77,34 @@ class MindsDBParser(Parser):
 
     # Set
 
-    @_('SET expr')
+    @_('SET expr_list')
+    @_('SET set_modifier expr_list')
     def set(self, p):
-        return Set(arg=p.expr)
+        if len(p.expr_list) == 1:
+            arg = p.expr_list[0]
+        else:
+            arg = Tuple(items=p.expr_list)
+
+        if hasattr(p, 'set_modifier'):
+            category = p.set_modifier
+        else:
+            category = None
+
+        return Set(category=category, arg=arg)
 
     @_('SET ID identifier')
     def set(self, p):
         if not p.ID.lower() == 'names':
             raise ParsingException(f'Expected "SET names", got "SET {p.ID}"')
         return Set(category=p.ID.lower(), arg=p.identifier)
+
+    @_('GLOBAL',
+       'PERSIST',
+       'PERSIST_ONLY',
+       'SESSION',
+       )
+    def set_modifier(self, p):
+        return p[0]
 
     # Show
 

--- a/mindsdb_sql/parser/dialects/mysql/parser.py
+++ b/mindsdb_sql/parser/dialects/mysql/parser.py
@@ -93,6 +93,21 @@ class MySQLParser(SQLParser):
     def set_modifier(self, p):
         return p[0]
 
+    @_('SET charset constant')
+    @_('SET charset DEFAULT')
+    def set(self, p):
+        if hasattr(p, 'DEFAULT'):
+            arg = SpecialConstant('DEFAULT')
+        else:
+            arg = p.constant
+        return Set(category='CHARSET', arg=arg)
+
+    @_('CHARACTER SET',
+       'CHARSET',
+       )
+    def charset(self, p):
+        return p[0]
+
     # Show
     @_('SHOW show_category show_condition_or_nothing')
     def show(self, p):

--- a/mindsdb_sql/parser/dialects/mysql/parser.py
+++ b/mindsdb_sql/parser/dialects/mysql/parser.py
@@ -68,10 +68,6 @@ class MySQLParser(SQLParser):
     def set(self, p):
         return Set(arg=p.expr)
 
-    @_('SET AUTOCOMMIT')
-    def set(self, p):
-        return Set(category=p.AUTOCOMMIT)
-
     @_('SET ID identifier')
     def set(self, p):
         if not p.ID.lower() == 'names':

--- a/mindsdb_sql/parser/dialects/mysql/parser.py
+++ b/mindsdb_sql/parser/dialects/mysql/parser.py
@@ -93,6 +93,7 @@ class MySQLParser(SQLParser):
     def set_modifier(self, p):
         return p[0]
 
+    # set charset
     @_('SET charset constant')
     @_('SET charset DEFAULT')
     def set(self, p):
@@ -107,6 +108,58 @@ class MySQLParser(SQLParser):
        )
     def charset(self, p):
         return p[0]
+
+    # set transaction
+    @_('SET transact_scope TRANSACTION transact_property_list')
+    def set(self, p):
+        isolation_level = None
+        access_mode = None
+        for prop in p.transact_property_list:
+            if prop['type'] == 'iso_level':
+                isolation_level = prop['value']
+            else:
+                access_mode = prop['value']
+
+        return SetTransaction(
+            isolation_level=isolation_level,
+            access_mode=access_mode,
+            scope=p.transact_scope,
+        )
+
+    @_('GLOBAL',
+       'SESSION',
+       'empty')
+    def transact_scope(self, p):
+        return p[0]
+
+    @_('transact_property_list COMMA transact_property')
+    def transact_property_list(self, p):
+        return p.transact_property_list + [p.transact_property]
+
+    @_('transact_property')
+    def transact_property_list(self, p):
+        return [p[0]]
+
+    @_('ISOLATION LEVEL transact_level',
+       'transact_access_mode')
+    def transact_property(self, p):
+        if hasattr(p, 'transact_level'):
+            return {'type': 'iso_level', 'value': p.transact_level}
+        else:
+            return {'type': 'access_mode', 'value': p.transact_access_mode}
+
+    @_('REPEATABLE READ',
+       'READ COMMITTED',
+       'READ UNCOMMITTED',
+       'SERIALIZABLE')
+    def transact_level(self, p):
+        return ' '.join([x for x in p])
+
+    @_('READ WRITE',
+       'READ ONLY')
+    def transact_access_mode(self, p):
+        return ' '.join([x for x in p])
+
 
     # Show
     @_('SHOW show_category show_condition_or_nothing')

--- a/mindsdb_sql/parser/lexer.py
+++ b/mindsdb_sql/parser/lexer.py
@@ -11,6 +11,8 @@ class SQLLexer(Lexer):
 
         # Misc
         SET, AUTOCOMMIT, START, TRANSACTION, COMMIT, ROLLBACK, ALTER, EXPLAIN,
+        ISOLATION, LEVEL, REPEATABLE, READ, WRITE, UNCOMMITTED, COMMITTED,
+        SERIALIZABLE, ONLY,
 
         # SHOW Keywords
 
@@ -52,6 +54,15 @@ class SQLLexer(Lexer):
     ROLLBACK = r'\bROLLBACK\b'
     EXPLAIN = r'\bEXPLAIN\b'
     ALTER = r'\bALTER\b'
+    ISOLATION = r'\bISOLATION\b'
+    LEVEL = r'\bLEVEL\b'
+    REPEATABLE = r'\bREPEATABLE\b'
+    READ = r'\bREAD\b'
+    WRITE = r'\bWRITE\b'
+    UNCOMMITTED = r'\bUNCOMMITTED\b'
+    COMMITTED = r'\bCOMMITTED\b'
+    SERIALIZABLE = r'\bSERIALIZABLE\b'
+    ONLY = r'\bONLY\b'
 
     USE = r'\bUSE\b'
     DESCRIBE = r'\bDESCRIBE\b'

--- a/mindsdb_sql/parser/lexer.py
+++ b/mindsdb_sql/parser/lexer.py
@@ -18,7 +18,7 @@ class SQLLexer(Lexer):
         VARIABLES, SESSION, STATUS,
         GLOBAL, PROCEDURE, FUNCTION, INDEX, WARNINGS,
         ENGINES, CHARSET, COLLATION, PLUGINS, CHARACTER,
-        PERSIST, PERSIST_ONLY,
+        PERSIST, PERSIST_ONLY, DEFAULT,
 
 
         # SELECT Keywords
@@ -79,7 +79,7 @@ class SQLLexer(Lexer):
     PLUGINS = r'\bPLUGINS\b'
     PERSIST = r'\bPERSIST\b'
     PERSIST_ONLY = r'\bPERSIST_ONLY\b'
-
+    DEFAULT = r'\bDEFAULT\b'
 
     # SELECT
 

--- a/mindsdb_sql/parser/lexer.py
+++ b/mindsdb_sql/parser/lexer.py
@@ -18,6 +18,7 @@ class SQLLexer(Lexer):
         VARIABLES, SESSION, STATUS,
         GLOBAL, PROCEDURE, FUNCTION, INDEX, WARNINGS,
         ENGINES, CHARSET, COLLATION, PLUGINS, CHARACTER,
+        PERSIST, PERSIST_ONLY,
 
 
         # SELECT Keywords
@@ -76,6 +77,8 @@ class SQLLexer(Lexer):
     CHARACTER = r'\bCHARACTER\b'
     COLLATION = r'\bCOLLATION\b'
     PLUGINS = r'\bPLUGINS\b'
+    PERSIST = r'\bPERSIST\b'
+    PERSIST_ONLY = r'\bPERSIST_ONLY\b'
 
 
     # SELECT

--- a/mindsdb_sql/parser/parser.py
+++ b/mindsdb_sql/parser/parser.py
@@ -61,10 +61,6 @@ class SQLParser(Parser):
 
     # Set
 
-    @_('SET AUTOCOMMIT')
-    def set(self, p):
-        return Set(category=p.AUTOCOMMIT)
-
     @_('SET expr')
     def set(self, p):
         return Set(arg=p.expr)

--- a/tests/test_parser/test_base_sql/test_misc_sql_queries.py
+++ b/tests/test_parser/test_base_sql/test_misc_sql_queries.py
@@ -73,3 +73,17 @@ class TestMiscQueries:
         assert str(ast) == str(expected_ast)
 
 
+@pytest.mark.parametrize('dialect', ['mysql', 'mindsdb'])
+class TestMiscQueriesNoSqlite:
+    def test_set(self, dialect):
+
+        sql = "set var1 = NULL, var2 = 10"
+
+        ast = parse_sql(sql, dialect=dialect)
+        expected_ast = Set(arg=Tuple(items=[
+                BinaryOperation('=', args=[Identifier('var1'), NullConstant()]),
+                BinaryOperation('=', args=[Identifier('var2'), Constant(10)]),
+            ])
+                           )
+        assert ast.to_tree() == expected_ast.to_tree()
+        assert str(ast) == str(expected_ast)

--- a/tests/test_parser/test_base_sql/test_misc_sql_queries.py
+++ b/tests/test_parser/test_base_sql/test_misc_sql_queries.py
@@ -11,19 +11,6 @@ class TestMiscQueries:
     def test_set(self, dialect):
         lexer, parser = get_lexer_parser(dialect)
 
-        sql = "set autocommit"
-
-        tokens = list(lexer.tokenize(sql))
-
-        assert len(tokens) == 2
-        assert tokens[0].type == 'SET'
-        assert tokens[1].type == 'AUTOCOMMIT'
-
-        ast = parse_sql(sql, dialect=dialect)
-        expected_ast = Set(category="autocommit")
-        assert ast.to_tree() == expected_ast.to_tree()
-        assert str(ast) == str(expected_ast)
-
         sql = "SET NAMES some_name"
 
         ast = parse_sql(sql, dialect=dialect)

--- a/tests/test_parser/test_base_sql/test_misc_sql_queries.py
+++ b/tests/test_parser/test_base_sql/test_misc_sql_queries.py
@@ -113,4 +113,48 @@ class TestMiscQueriesNoSqlite:
         assert ast.to_tree() == expected_ast.to_tree()
         assert str(ast) == str(expected_ast)
 
+    def test_set_transaction(self, dialect):
+
+        sql = "SET GLOBAL TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ WRITE"
+
+        ast = parse_sql(sql, dialect=dialect)
+        expected_ast = SetTransaction(
+            isolation_level='REPEATABLE READ',
+            access_mode='READ WRITE',
+            scope='GLOBAL')
+
+        assert ast.to_tree() == expected_ast.to_tree()
+        assert str(ast) == str(expected_ast)
+
+        sql = "SET SESSION TRANSACTION READ ONLY, ISOLATION LEVEL SERIALIZABLE"
+
+        ast = parse_sql(sql, dialect=dialect)
+        expected_ast = SetTransaction(
+            isolation_level='SERIALIZABLE',
+            access_mode='READ ONLY',
+            scope='SESSION')
+
+        assert ast.to_tree() == expected_ast.to_tree()
+        assert str(ast) == str(expected_ast)
+
+        sql = "SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED"
+
+        ast = parse_sql(sql, dialect=dialect)
+        expected_ast = SetTransaction(
+            isolation_level='READ UNCOMMITTED'
+        )
+
+        assert ast.to_tree() == expected_ast.to_tree()
+        assert str(ast) == str(expected_ast)
+
+        sql = "SET TRANSACTION READ ONLY"
+
+        ast = parse_sql(sql, dialect=dialect)
+        expected_ast = SetTransaction(
+            access_mode='READ ONLY'
+        )
+
+        assert ast.to_tree() == expected_ast.to_tree()
+        assert str(ast) == str(expected_ast)
+
 

--- a/tests/test_parser/test_base_sql/test_misc_sql_queries.py
+++ b/tests/test_parser/test_base_sql/test_misc_sql_queries.py
@@ -87,3 +87,30 @@ class TestMiscQueriesNoSqlite:
                            )
         assert ast.to_tree() == expected_ast.to_tree()
         assert str(ast) == str(expected_ast)
+
+    def test_set_charset(self, dialect):
+
+        sql = "SET CHARACTER SET DEFAULT"
+
+        ast = parse_sql(sql, dialect=dialect)
+        expected_ast = Set(category='CHARSET', arg=SpecialConstant('DEFAULT'))
+
+        assert ast.to_tree() == expected_ast.to_tree()
+
+        sql = "SET CHARSET DEFAULT"
+
+        ast = parse_sql(sql, dialect=dialect)
+        expected_ast = Set(category='CHARSET', arg=SpecialConstant('DEFAULT'))
+
+        assert ast.to_tree() == expected_ast.to_tree()
+        assert str(ast) == str(expected_ast)
+
+        sql = "SET CHARSET 'utf8'"
+
+        ast = parse_sql(sql, dialect=dialect)
+        expected_ast = Set(category='CHARSET', arg=Constant('utf8'))
+
+        assert ast.to_tree() == expected_ast.to_tree()
+        assert str(ast) == str(expected_ast)
+
+


### PR DESCRIPTION
#123

1. removed support of 'set autocommit'
2. support of multiple vars in SET (mysql and mindsdb):
- 'SET [modifier] variable = expr [, variable = expr] ...' 
- modifiers: SESSION/GLOBAL/PERSIST/PERSIST_ONLY
3. support SET CAHRSET (mysql and mindsdb): 
- SET {CHARACTER SET | CHARSET} {'charset_name' | DEFAULT}
4. support SET TRANSACTION
- SET [GLOBAL | SESSION] TRANSACTION [ISOLATION LEVEL ...] [, ...]