### PR TITLE
Handle 'select * from mindsdb.predictors' by planner properly

### DIFF
--- a/mindsdb_sql/planner/query_planner.py
+++ b/mindsdb_sql/planner/query_planner.py
@@ -45,8 +45,12 @@ class QueryPlanner():
     def is_predictor(self, identifier):
         parts = identifier.parts
         if parts[0].lower() == self.predictor_namespace:
+            if parts[-1].lower() == 'predictors':
+                return False
             return True
         elif len(parts) == 1 and self.default_namespace == self.predictor_namespace:
+            if parts[-1].lower() == 'predictors':
+                return False
             return True
         return False
 

--- a/tests/test_planner/test_mindsdb_predictors_select.py
+++ b/tests/test_planner/test_mindsdb_predictors_select.py
@@ -1,0 +1,47 @@
+import pytest
+
+from mindsdb_sql import parse_sql
+from mindsdb_sql.exceptions import PlanningException
+from mindsdb_sql.parser.ast import *
+from mindsdb_sql.planner import plan_query
+from mindsdb_sql.planner.query_plan import QueryPlan
+from mindsdb_sql.planner.step_result import Result
+from mindsdb_sql.planner.steps import (FetchDataframeStep, ProjectStep, FilterStep, JoinStep, ApplyPredictorStep,
+                                       ApplyPredictorRowStep, GroupByStep)
+
+
+class TestPlanPredictorsSelect:
+    def test_predictors_select_plan(self):
+        query = Select(targets=[Identifier('column1'), Constant(1), NullConstant(), Function('database', args=[])],
+                       from_table=Identifier('mindsdb.predictors'),
+                       where=BinaryOperation('and', args=[
+                           BinaryOperation('=', args=[Identifier('column1'), Identifier('column2')]),
+                           BinaryOperation('>', args=[Identifier('column3'), Constant(0)]),
+                       ]))
+        expected_plan = QueryPlan(integrations=['mindsdb'],
+                                  steps=[
+                                      FetchDataframeStep(integration='mindsdb',
+                                                         query=Select(targets=[Identifier('predictors.column1', alias=Identifier('column1')),
+                                                                               Constant(1),
+                                                                               NullConstant(),
+                                                                               Function('database', args=[]),
+                                                                               ],
+                                                                      from_table=Identifier('predictors'),
+                                                                      where=BinaryOperation('and', args=[
+                                                                              BinaryOperation('=',
+                                                                                              args=[Identifier('predictors.column1'),
+                                                                                                    Identifier('predictors.column2')]),
+                                                                              BinaryOperation('>',
+                                                                                              args=[Identifier('predictors.column3'),
+                                                                                                    Constant(0)]),
+                                                                          ])
+                                                                      ),
+                                                         step_num=0,
+                                                         references=None,
+                                                         ),
+                                  ])
+
+        plan = plan_query(query, integrations=['mindsdb'])
+
+        for i in range(len(plan.steps)):
+            assert plan.steps[i] == expected_plan.steps[i]


### PR DESCRIPTION
you'll get next error while try to create a plan based on parsed 'select * from mindsdb.predictors' query:
```
query = "select * from predictors where name = 'foo'"
for d in ['mindsdb', 'mysql']:
    parsed = parse_sql(query, dialect=d)
    print(parsed)         
    plan = plan_query(parsed, default_namespace='mindsdb', integrations=['mindsdb', ])
    print(plan.steps)    
```

```
Traceback (most recent call last):
  File "tmp.py", line 42, in <module>
    plan = plan_query(parsed, default_namespace='mindsdb')
  File "/home/itsyplen/repos/work/MindsDB/mindsdb_sql/mindsdb_sql/planner/__init__.py", line 5, in plan_query
    return QueryPlanner(query, *args, **kwargs).from_query()
  File "/home/itsyplen/repos/work/MindsDB/mindsdb_sql/mindsdb_sql/planner/query_planner.py", line 561, in from_query
    self.plan_select(query)
  File "/home/itsyplen/repos/work/MindsDB/mindsdb_sql/mindsdb_sql/planner/query_planner.py", line 539, in plan_select
    return self.plan_select_from_predictor(query)
  File "/home/itsyplen/repos/work/MindsDB/mindsdb_sql/mindsdb_sql/planner/query_planner.py", line 126, in plan_select_from_predictor
    raise PlanningException(f'WHERE clause required when selecting from predictor')
mindsdb_sql.exceptions.PlanningException: WHERE clause required when selecting from predictor
```