### PR TITLE
Release 0.4.10

### DIFF
--- a/mindsdb_sql/__about__.py
+++ b/mindsdb_sql/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'mindsdb_sql'
 __package_name__ = 'mindsdb_sql'
-__version__ = '0.4.9'
+__version__ = '0.4.10'
 __description__ = "Pure python SQL parser"
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb_sql/parser/dialects/mindsdb/create_database.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/create_database.py
@@ -40,5 +40,8 @@ class CreateDatabase(ASTNode):
         if self.is_replace:
             replace_str = f' OR REPLACE'
 
-        out_str = f'CREATE{replace_str} DATABASE {str(self.name)} WITH ENGINE = {repr(self.engine)}, PARAMETERS = {json.dumps(self.parameters)}'
+        parameters_str = ''
+        if self.parameters:
+            parameters_str = f', PARAMETERS = {json.dumps(self.parameters)}'
+        out_str = f'CREATE{replace_str} DATABASE {str(self.name)} WITH ENGINE = {repr(self.engine)}{parameters_str}'
         return out_str

--- a/mindsdb_sql/parser/dialects/mindsdb/create_predictor.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/create_predictor.py
@@ -93,7 +93,7 @@ class CreatePredictorBase(ASTNode):
         window_str = f'WINDOW {self.window} ' if self.window is not None else ''
         horizon_str = f'HORIZON {self.horizon} ' if self.horizon is not None else ''
         using_str = ''
-        if self.using is not None:
+        if self.using:
             using_ar = []
             for key, value in self.using.items():
                 if isinstance(value, Object):

--- a/mindsdb_sql/planner/query_planner.py
+++ b/mindsdb_sql/planner/query_planner.py
@@ -802,7 +802,7 @@ class QueryPlanner():
             if query.from_table.alias is not None:
                 table_alias = [query.from_table.alias.parts[0]]
             else:
-                table_alias = [query.from_table.parts[-1]]
+                table_alias = query.from_table.parts
 
             # add latest to query.where
             for cond in moved_conditions:


### PR DESCRIPTION
Changes:
- Support params for model in where clause:
```
   select * from int.tab1 a
        join pred.1 p
        where a.x=1 and p.x=1 and a.y=3 and p.a='' 
```
Is the same as:
```
   select * from int.tab1 a
        join pred.1 p
        where a.x=1 and a.y=3 
       using x=1, a='' 
```

Fixes:
- internal render fixes
- fix planning subquery whit 3 level table:
```
SELECT
home_rentals.rental_price AS real_price,
 home_rentals_model.rental_price AS predicted_price
  FROM
 (
   SELECT * FROM example_db.demo_data.home_rentals
    WHERE number_of_rooms = 2
  )
   JOIN mindsdb.home_rentals_model
```