### PR TITLE
Release 0.5.1

### DIFF
--- a/mindsdb_sql/__about__.py
+++ b/mindsdb_sql/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'mindsdb_sql'
 __package_name__ = 'mindsdb_sql'
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 __description__ = "Pure python SQL parser"
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb_sql/parser/ast/select/parameter.py
+++ b/mindsdb_sql/parser/ast/select/parameter.py
@@ -6,8 +6,11 @@ class Parameter(ASTNode):
         super().__init__(*args, **kwargs)
         self.value = value
 
+    def __repr__(self):
+        return f'Parameter({self.value})'
+
     def to_tree(self, *args, level=0, **kwargs):
         return '\t' * level + f'Parameter({repr(self.value)})'
 
     def get_string(self, *args, **kwargs):
-        return self.value
+        return str(self.value)

--- a/mindsdb_sql/parser/dialects/mindsdb/lexer.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/lexer.py
@@ -28,7 +28,7 @@ class MindsDBLexer(Lexer):
         MODEL, MODELS, ML_ENGINE, ML_ENGINES, HANDLERS,
         FINETUNE,
         LATEST, HORIZON, USING,
-        ENGINE, TRAIN, PREDICT, PARAMETERS, JOB, EVERY,
+        ENGINE, TRAIN, PREDICT, PARAMETERS, JOB, EVERY,PROJECT,
 
         # SHOW/DDL Keywords
 
@@ -106,6 +106,7 @@ class MindsDBLexer(Lexer):
     HANDLERS = r'\bHANDLERS\b'
     JOB = r'\bJOB\b'
     EVERY = r'\bEVERY\b'
+    PROJECT = r'\bPROJECT\b'
 
     # Misc
     SET = r'\bSET\b'

--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -169,6 +169,7 @@ class MindsDBParser(Parser):
     # DROP DATABASE
     @_('DROP DATABASE identifier',
        'DROP DATABASE IF_EXISTS identifier',
+       'DROP PROJECT identifier',
        'DROP SCHEMA identifier',
        'DROP SCHEMA IF_EXISTS identifier')
     def drop_database(self, p):
@@ -713,6 +714,7 @@ class MindsDBParser(Parser):
                                 parameters=parameters)
 
     @_('DATABASE id',
+       'PROJECT id',
        'DATABASE id ENGINE string',
        'DATABASE id ENGINE EQUALS string',
        'DATABASE id WITH ENGINE string',

--- a/tests/test_parser/test_mindsdb/test_create_integration.py
+++ b/tests/test_parser/test_mindsdb/test_create_integration.py
@@ -79,3 +79,14 @@ class TestCreateDatabase:
         sql = "CREATE DATABASE db WITH ENGINE = 'mysql', PARAMETERS = 'wow'"
         with pytest.raises(ParsingException):
             ast = parse_sql(sql, dialect='mindsdb')
+
+    def test_create_project(self):
+
+        sql = "create PROJECT dbname"
+        ast = parse_sql(sql, dialect='mindsdb')
+
+        expected_ast = CreateDatabase(name='dbname', engine=None, parameters=None)
+
+        assert str(ast).lower() == str(expected_ast).lower()
+        assert ast.to_tree() == expected_ast.to_tree()
+

--- a/tests/test_parser/test_mindsdb/test_drop_datasource.py
+++ b/tests/test_parser/test_mindsdb/test_drop_datasource.py
@@ -13,3 +13,14 @@ class TestDropDatasource:
         assert str(ast).lower() == sql.lower()
         assert str(ast) == str(expected_ast)
         assert ast.to_tree() == expected_ast.to_tree()
+
+    def test_drop_project(self):
+
+        sql = "DROP PROJECT dbname"
+        ast = parse_sql(sql, dialect='mindsdb')
+
+        expected_ast = DropDatabase(name=Identifier('dbname'), if_exists=False)
+
+        assert str(ast).lower() == str(expected_ast).lower()
+        assert ast.to_tree() == expected_ast.to_tree()
+

--- a/tests/test_planner/test_select_from_predictor.py
+++ b/tests/test_planner/test_select_from_predictor.py
@@ -259,8 +259,8 @@ class TestPlanSelectFromPredictor:
 
     def test_select_from_table_subselect(self):
         query = parse_sql('''
-            select * from int2.t2
-            where x1 in (select id from int1.t1)
+            select * from int2.tab1
+            where x1 in (select id from int1.tab1)
         ''', dialect='mindsdb')
 
         expected_plan = QueryPlan(
@@ -268,17 +268,17 @@ class TestPlanSelectFromPredictor:
             steps=[
                 FetchDataframeStep(
                     integration='int1',
-                    query=parse_sql('select t1.id as id from t1'),
+                    query=parse_sql('select tab1.id as id from tab1'),
                 ),
                 FetchDataframeStep(
                     integration='int2',
                     query=Select(
                         targets=[Star()],
-                        from_table=Identifier('t2'),
+                        from_table=Identifier('tab1'),
                         where=BinaryOperation(
                             op='in',
                             args=[
-                                Identifier(parts=['t2', 'x1']),
+                                Identifier(parts=['tab1', 'x1']),
                                 Parameter(Result(0))
                             ]
                         )


### PR DESCRIPTION
Changes:

1. support different integrations in simple select. These queries are supported now:
```
select * from model1 where x = (select id from integration1.table1 where a=1)

select * from integration2.table2 where x in (select id from integration1.table1 where a=1)

select (select id from integration1.table1 where a=1) as x from integration2.table2
```

2. Syntax sugar:
- 'create project aa' == 'create database aa'
- 'drop project aa' == 'drop database aa'

