### PR TITLE
Fix for issue #272

### DIFF
--- a/mindsdb_sql/parser/ast/select/identifier.py
+++ b/mindsdb_sql/parser/ast/select/identifier.py
@@ -8,7 +8,7 @@ no_wrap_identifier_regex = re.compile(r'[a-zA-Z_][a-zA-Z_0-9]*')
 path_str_parts_regex = re.compile(r'(?:(?:(`[^`]+`))|([^.]+))')
 
 
-def path_str_to_parts(path_str):
+def path_str_to_parts(path_str: str):
     match = re.finditer(path_str_parts_regex, path_str)
     parts = [x[0].strip('`') for x in match]
     return parts
@@ -25,6 +25,9 @@ class Identifier(ASTNode):
         super().__init__(*args, **kwargs)
         assert path_str or parts, "Either path_str or parts must be provided for an Identifier"
         assert not (path_str and parts), "Provide either path_str or parts, but not both"
+        if isinstance(path_str, Star) and not parts:
+            parts = [Star()]
+
         if path_str and not parts:
             parts = path_str_to_parts(path_str)
         assert isinstance(parts, list)
@@ -66,5 +69,3 @@ class Identifier(ASTNode):
 
     def get_string(self, *args, **kwargs):
         return self.parts_to_str()
-
-

--- a/mindsdb_sql/planner/utils.py
+++ b/mindsdb_sql/planner/utils.py
@@ -53,7 +53,7 @@ def disambiguate_integration_column_identifier(identifier, integration_name, tab
     new_identifier = Identifier(parts=parts)
     if identifier.alias:
         new_identifier.alias = identifier.alias
-    elif initial_name_as_alias:
+    elif initial_name_as_alias and not isinstance(parts[-1], Star):
         new_identifier.alias = Identifier(parts[-1])
 
     return new_identifier


### PR DESCRIPTION
Added proper handling when using 
```
`select `table`.* from `table`
```

After running: 
```py
from mindsdb_sql.planner import query_planner
from mindsdb_sql import parse_sql

planner = query_planner.QueryPlanner(
    parse_sql("""SELECT `models`.* FROM `models`""", dialect='mindsdb'),
    integrations=['information_schema', 'mindsdb', 'files', 'bespoke'],
    predictor_metadata=[],
    default_namespace='mindsdb'
)

for step in planner.execute_steps():
    print(step)
```

Output is: 
```py
FetchDataframeStep(step_num=0, references=[], result_data=None, integration=mindsdb, query=SELECT `models`.* FROM `models`, raw_query=None)
```

This fixes issue when running this query on mindsdb and returns models

Fixes: #272