### PR TITLE
Release 0.6.4

### DIFF
--- a/mindsdb_sql/__about__.py
+++ b/mindsdb_sql/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'mindsdb_sql'
 __package_name__ = 'mindsdb_sql'
-__version__ = '0.6.3'
+__version__ = '0.6.4'
 __description__ = "Pure python SQL parser"
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb_sql/planner/query_planner.py
+++ b/mindsdb_sql/planner/query_planner.py
@@ -4,13 +4,14 @@ from mindsdb_sql.exceptions import PlanningException
 from mindsdb_sql.parser import ast
 from mindsdb_sql.parser.ast import (Select, Identifier, Join, Star, BinaryOperation, Constant, OrderBy,
                                     BetweenOperation, Union, NullConstant, CreateTable, Function, Insert,
-                                    Update, NativeQuery, Parameter)
+                                    Update, NativeQuery, Parameter, Delete)
 
 from mindsdb_sql.parser.dialects.mindsdb.latest import Latest
 from mindsdb_sql.planner.steps import (FetchDataframeStep, ProjectStep, JoinStep, ApplyPredictorStep,
                                        ApplyPredictorRowStep, FilterStep, GroupByStep, LimitOffsetStep, OrderByStep,
                                        UnionStep, MapReduceStep, MultipleSteps, ApplyTimeseriesPredictorStep,
-                                       GetPredictorColumns, SaveToTable, InsertToTable, UpdateToTable, SubSelectStep)
+                                       GetPredictorColumns, SaveToTable, InsertToTable, UpdateToTable, SubSelectStep,
+                                       DeleteStep)
 from mindsdb_sql.planner.ts_utils import (validate_ts_where_condition, find_time_filter, replace_time_filter,
                                           find_and_remove_time_filter)
 from mindsdb_sql.planner.utils import (disambiguate_predictor_column_identifier,
@@ -220,6 +221,27 @@ class QueryPlanner():
         utils.query_traversal(query, find_predictors)
         return {'mdb_entities': mdb_entities, 'integrations': integrations, 'predictors': predictors}
 
+    def get_nested_selects_plan_fnc(self, main_integration, force=False):
+        # returns function for traversal over query and inject fetch data query instead of subselects
+        def find_selects(node, **kwargs):
+            if isinstance(node, Select):
+                query_info2 = self.get_query_info(node)
+                if force or (
+                        len(query_info2['integrations']) > 1 or
+                        main_integration not in query_info2['integrations'] or
+                        len(query_info2['mdb_entities']) > 0
+                ):
+                    # need to execute in planner
+
+                    node.parentheses = False
+                    last_step = self.plan_select(node)
+                    node2 = Parameter(last_step.result)
+
+                    return node2
+
+        return find_selects
+
+
     def plan_select_identifier(self, query):
         query_info = self.get_query_info(query)
 
@@ -235,23 +257,9 @@ class QueryPlanner():
 
         # find subselects
         main_integration, _ = self.resolve_database_table(query.from_table)
+        is_api_db = self.integrations.get(main_integration, {}).get('class_type') == 'api'
 
-        def find_selects(node, **kwargs):
-            if isinstance(node, Select):
-                query_info2 = self.get_query_info(node)
-                if (
-                        len(query_info2['integrations']) > 1 or
-                        main_integration not in query_info2['integrations'] or
-                        len(query_info2['mdb_entities']) > 0
-                ):
-                    # need to execute in planner
-
-                    node.parentheses = False
-                    last_step = self.plan_select(node)
-                    node2 = Parameter(last_step.result)
-
-                    return node2
-
+        find_selects = self.get_nested_selects_plan_fnc(main_integration, force=is_api_db)
         query.targets = utils.query_traversal(query.targets, find_selects)
         utils.query_traversal(query.where, find_selects)
 
@@ -1110,6 +1118,23 @@ class QueryPlanner():
             update_command=update_command
         ))
 
+    def plan_delete(self, query: Delete):
+
+        # find subselects
+        main_integration, _ = self.resolve_database_table(query.table)
+
+        is_api_db = self.integrations.get(main_integration, {}).get('class_type') == 'api'
+
+        find_selects = self.get_nested_selects_plan_fnc(main_integration, force=is_api_db)
+        utils.query_traversal(query.where, find_selects)
+
+        self.prepare_integration_select(main_integration, query.where)
+
+        return self.plan.add_step(DeleteStep(
+            table=query.table,
+            where=query.where
+        ))
+
     def plan_select(self, query, integration=None):
         from_table = query.from_table
 
@@ -1172,6 +1197,8 @@ class QueryPlanner():
             self.plan_insert(query)
         elif isinstance(query, Update):
             self.plan_update(query)
+        elif isinstance(query, Delete):
+            self.plan_delete(query)
         else:
             raise PlanningException(f'Unsupported query type {type(query)}')
 

--- a/mindsdb_sql/planner/query_planner.py
+++ b/mindsdb_sql/planner/query_planner.py
@@ -1093,14 +1093,12 @@ class QueryPlanner():
             ))
 
     def plan_update(self, query):
-        if query.from_select is None:
-            raise PlanningException(f'Support only insert from select')
-
-        integration_name = query.table.parts[0]
+        last_step = None
+        if query.from_select is not None:
+            integration_name = query.table.parts[0]
+            last_step = self.plan_select(query.from_select, integration=integration_name)
 
         # plan sub-select first
-        last_step = self.plan_select(query.from_select, integration=integration_name)
-
         update_command = copy.deepcopy(query)
         # clear subselect
         update_command.from_select = None

--- a/mindsdb_sql/planner/query_prepare.py
+++ b/mindsdb_sql/planner/query_prepare.py
@@ -519,6 +519,7 @@ class PreparedStatementPlanner():
                 or isinstance(query, ast.CreateTable)
                 or isinstance(query, ast.Insert)
                 or isinstance(query, ast.Update)
+                or isinstance(query, ast.Delete)
         ):
             return self.plan_query(query)
         else:

--- a/mindsdb_sql/planner/steps.py
+++ b/mindsdb_sql/planner/steps.py
@@ -235,6 +235,14 @@ class UpdateToTable(PlanStep):
         self.update_command = update_command
 
 
+class DeleteStep(PlanStep):
+    def __init__(self, table, where, *args, **kwargs):
+        """Fills table with content of dataframe"""
+        super().__init__(*args, **kwargs)
+        self.table = table
+        self.where = where
+
+
 class SubSelectStep(PlanStep):
     def __init__(self, query, dataframe, table_name=None, *args, **kwargs):
         """Performs select from dataframe"""

--- a/tests/test_planner/test_integration_select.py
+++ b/tests/test_planner/test_integration_select.py
@@ -7,7 +7,7 @@ from mindsdb_sql.planner import plan_query
 from mindsdb_sql.planner.query_plan import QueryPlan
 from mindsdb_sql.planner.step_result import Result
 from mindsdb_sql.planner.steps import (FetchDataframeStep, ProjectStep, FilterStep, JoinStep, ApplyPredictorStep,
-                                       ApplyPredictorRowStep, GroupByStep, SubSelectStep)
+                                       ApplyPredictorRowStep, GroupByStep, SubSelectStep, UpdateToTable)
 
 
 class TestPlanIntegrationSelect:
@@ -453,3 +453,23 @@ class TestPlanIntegrationSelect:
         )
         for i in range(len(plan.steps)):
             assert plan.steps[i] == expected_plan.steps[i]
+
+    def test_update_table(self):
+
+        # select on results after select to integration
+
+        sql = "update integration1.direct_messages set a=1 where b=2"
+        query = parse_sql(sql, dialect='mindsdb')
+
+        plan = plan_query(query, integrations=['integration1'])
+
+        expected_plan = QueryPlan(
+            default_namespace='integration1',
+            steps=[
+                UpdateToTable(dataframe=None, table=Identifier('integration1.direct_messages'),
+                              update_command=query),
+            ]
+        )
+        for i in range(len(plan.steps)):
+            assert plan.steps[i] == expected_plan.steps[i]
+


### PR DESCRIPTION
Changes in planner:
- support regular update command in integration:
```
update integration.table set a=1 where b=2
```
- support delete command regular and with subselect:
```
delete from integration.table where a=2
```

If integration are different or this is API database,  this query splits to 2 SQLs in planner ('select' and 'delete')
```
delete from integration.table where a in (select id from integration.table where b=2)
```

