### PR TITLE
Add UPDATE MindsDB SQL Command for Chatbots

### DIFF
--- a/mindsdb_sql/parser/dialects/mindsdb/__init__.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/__init__.py
@@ -14,7 +14,7 @@ from .create_ml_engine import CreateMLEngine
 from .drop_ml_engine import DropMLEngine
 from .create_job import CreateJob
 from .drop_job import DropJob
-from .chatbot import CreateChatBot, DropChatBot
+from .chatbot import CreateChatBot, UpdateChatBot, DropChatBot
 
 # remove it in next release
 CreateDatasource = CreateDatabase

--- a/mindsdb_sql/parser/dialects/mindsdb/chatbot.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/chatbot.py
@@ -43,6 +43,29 @@ class CreateChatBot(ASTNode):
         return out_str
 
 
+class UpdateChatBot(ASTNode):
+    def __init__(self, name, updated_params, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.name = name
+        self.params = updated_params
+
+    def to_tree(self, *args, level=0, **kwargs):
+        ind = indent(level)
+        out_str = f'{ind}UpdateChatBot(' \
+                  f'name={self.name.to_string()}, ' \
+                  f'updated_params={self.params})'
+        return out_str
+
+    def get_string(self, *args, **kwargs):
+        params = self.params.copy()
+
+        set_ar = [f'{k}={repr(v)}' for k, v in params.items()]
+        set_str = ', '.join(set_ar)
+
+        out_str = f'UPDATE CHATBOT {self.name.to_string()} USING {set_str}'
+        return out_str
+
+
 class DropChatBot(ASTNode):
     def __init__(self,
                  name,

--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -10,7 +10,7 @@ from mindsdb_sql.parser.dialects.mindsdb.create_database import CreateDatabase
 from mindsdb_sql.parser.dialects.mindsdb.create_ml_engine import CreateMLEngine
 from mindsdb_sql.parser.dialects.mindsdb.create_view import CreateView
 from mindsdb_sql.parser.dialects.mindsdb.create_job import CreateJob
-from mindsdb_sql.parser.dialects.mindsdb.chatbot import CreateChatBot, DropChatBot
+from mindsdb_sql.parser.dialects.mindsdb.chatbot import CreateChatBot, UpdateChatBot, DropChatBot
 from mindsdb_sql.parser.dialects.mindsdb.drop_job import DropJob
 from mindsdb_sql.parser.dialects.mindsdb.latest import Latest
 from mindsdb_sql.parser.dialects.mindsdb.evaluate import Evaluate
@@ -73,13 +73,16 @@ class MindsDBParser(Parser):
        'create_table',
        'create_job',
        'drop_job',
+       'create_chat_bot',
+       'drop_chat_bot',
+       'update_chat_bot'
        )
     def query(self, p):
         return p[0]
 
     # -- ChatBot --
     @_('CREATE CHATBOT identifier USING kw_parameter_list')
-    def create_job(self, p):
+    def create_chat_bot(self, p):
         params = p.kw_parameter_list
 
         database = Identifier(params.pop('database'))
@@ -91,8 +94,13 @@ class MindsDBParser(Parser):
             params=params
         )
 
+    @_('UPDATE CHATBOT identifier SET kw_parameter_list')
+    def update_chat_bot(self, p):
+        return UpdateChatBot(name=p.identifier, updated_params=p.kw_parameter_list)
+
+
     @_('DROP CHATBOT identifier')
-    def drop_job(self, p):
+    def drop_chat_bot(self, p):
         return DropChatBot(name=p.identifier)
 
     # -- Jobs --

--- a/tests/test_parser/test_mindsdb/test_chatbots.py
+++ b/tests/test_parser/test_mindsdb/test_chatbots.py
@@ -38,6 +38,33 @@ class TestChatbots:
         assert str(ast) == str(expected_ast)
         assert ast.to_tree() == expected_ast.to_tree()
 
+    def test_update_chatbot(self):
+        sql = '''
+            update chatbot mybot
+            set
+            name = 'new_name',
+            model = 'new_model',
+            database = 'new_database',
+            chat_engine = 'new_chat_engine',
+            is_running = true,
+            new_param = 'new_value'
+        '''
+        ast = parse_sql(sql, dialect='mindsdb')
+        expected_params = {
+            'name': 'new_name',
+            'model': 'new_model',
+            'database': 'new_database',
+            'chat_engine': 'new_chat_engine',
+            'is_running': True,
+            'new_param': 'new_value'
+        }
+        expected_ast = UpdateChatBot(
+            name=Identifier('mybot'),
+            updated_params=expected_params
+        )
+        assert str(ast) == str(expected_ast)
+        assert ast.to_tree() == expected_ast.to_tree()
+
     def test_drop_chatbot(self):
         sql = '''
             drop chatbot mybot


### PR DESCRIPTION
This adds support for the `UPDATE` command for chatbots. Example:

```
UPDATE chatbot my_bot
SET
name = 'my_bot_updated',
model = 'test_model_updated',
app_token = 'new_app_token',
web_token = 'new_web_token',
```