### PR TITLE
Add Support for 'agent' Param for CREATE Chatbot Command

### DIFF
--- a/mindsdb_sql/parser/dialects/mindsdb/chatbot.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/chatbot.py
@@ -24,20 +24,22 @@ class CreateChatBot(ASTNode):
 
     def to_tree(self, *args, level=0, **kwargs):
         ind = indent(level)
+        model_str = self.model.to_string() if self.model else 'NULL'
+        agent_str = self.agent.to_string() if self.agent else 'NULL'
         out_str = f'{ind}CreateChatBot(' \
                   f'name={self.name.to_string()}, ' \
                   f'database={self.database.to_string()}, ' \
-                  f'model={self.model.to_string()}, ' \
-                  f'agent={self.agent.to_string()}, ' \
+                  f'model={model_str}, ' \
+                  f'agent={agent_str}, ' \
                   f'params={self.params})'
         return out_str
 
     def get_string(self, *args, **kwargs):
 
         params = self.params.copy()
-        params['model'] = self.model.to_string()
+        params['model'] = self.model.to_string() if self.model else 'NULL'
         params['database'] = self.database.to_string()
-        params['agent'] = self.agent.to_string()
+        params['agent'] = self.agent.to_string() if self.agent else 'NULL'
 
         using_ar = [f'{k}={repr(v)}' for k, v in params.items()]
 

--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -93,9 +93,9 @@ class MindsDBParser(Parser):
         model_param = params.pop('model', None)
         agent_param = params.pop('agent', None)
         model = Identifier(
-            model_param) if model_param is not None else NullConstant()
+            model_param) if model_param is not None else None
         agent = Identifier(
-            agent_param) if agent_param is not None else NullConstant()
+            agent_param) if agent_param is not None else None
         return CreateChatBot(
             name=p.identifier,
             database=database,

--- a/tests/test_parser/test_mindsdb/test_chatbots.py
+++ b/tests/test_parser/test_mindsdb/test_chatbots.py
@@ -35,7 +35,7 @@ class TestChatbots:
             name=Identifier('mybot'),
             database=Identifier('my_rocket_chat'),
             model=Identifier('chat_model'),
-            agent=NullConstant(),
+            agent=None,
             params={'key': 'value'}
         )
         assert str(ast) == str(expected_ast)


### PR DESCRIPTION
See [LLM Agent Design doc](https://docs.google.com/document/d/1QsgqJkhqusp1Ay9YCudoFXuoNzFHoDMMkXhr7AsW9IQ/edit#heading=h.rogj89libxhm) for more context.

This PR allows users to add the (optional) `agent` `USING` parameter which corresponds to the name of the agent the chatbot will be associated with. Also, the `model` `USING` parameter is now optional since the user can either define `agent` _or_ `model`. Eventually, we will only use `agent`, but we will support both until we remove the usage of `model` in the main `mindsdb` repo.

Related to #296 