### PR TITLE
add support for default embedding model in kb. 

### DIFF
--- a/mindsdb_sql/__about__.py
+++ b/mindsdb_sql/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'mindsdb_sql'
 __package_name__ = 'mindsdb_sql'
-__version__ = '0.8.0'
+__version__ = '0.8.1'
 __description__ = "Pure python SQL parser"
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb_sql/parser/dialects/mindsdb/knowledge_base.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/knowledge_base.py
@@ -9,7 +9,7 @@ class CreateKnowledgeBase(ASTNode):
     def __init__(
         self,
         name,
-        model,
+        model=None,
         storage=None,
         from_select=None,
         params=None,
@@ -37,13 +37,13 @@ class CreateKnowledgeBase(ASTNode):
     def to_tree(self, *args, level=0, **kwargs):
         ind = indent(level)
         storage_str = f"{ind} storage={self.storage.to_string()},\n" if self.storage else ""
+        model_str = f"{ind} model={self.model.to_string()},\n" if self.model else ""
         out_str = f"""
         {ind}CreateKnowledgeBase(
         {ind}    if_not_exists={self.if_not_exists},
         {ind}    name={self.name.to_string()},
         {ind}    from_query={self.from_query.to_tree(level=level + 1) if self.from_query else None},
-        {ind}    model={self.model.to_string()},
-        {storage_str}{ind}    params={self.params}
+        {model_str}{storage_str}{ind}    params={self.params}
         {ind})
         """
         return out_str
@@ -56,13 +56,13 @@ class CreateKnowledgeBase(ASTNode):
             f"FROM ({self.from_query.get_string()})" if self.from_query else ""
         )
         storage_str = f"  STORAGE = {self.storage.to_string()}" if self.storage else ""
+        model_str = f"  MODEL = {self.model.to_string()},\n" if self.model else ""
 
         out_str = (
             f"CREATE KNOWLEDGE_BASE {'IF NOT EXISTS' if self.if_not_exists else ''}{self.name.to_string()} "
             f"{from_query_str} "
             f"USING {using_str},"
-            f"  MODEL = {self.model.to_string()}, "
-            f"{storage_str}"
+            f"{model_str}{storage_str}"
         )
 
         return out_str

--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -117,11 +117,9 @@ class MindsDBParser(Parser):
             # convert to identifier
             storage = Identifier(storage)
 
-        if not model:
-            if isinstance(model, str):
-                # convert to identifier
-                model = Identifier(model)
-            raise ParsingException('Missing model parameter')
+        if isinstance(model, str):
+            # convert to identifier
+            model = Identifier(model)
 
         if_not_exists = p.if_not_exists_or_empty
 

--- a/tests/test_parser/test_mindsdb/test_knowledgebase.py
+++ b/tests/test_parser/test_mindsdb/test_knowledgebase.py
@@ -151,19 +151,21 @@ def test_create_knowledge_base():
     assert ast == expected_ast
 
     # create without USING ie no storage or model
-    sql = """
-        CREATE KNOWLEDGE_BASE my_knowledge_base
-    """
-    ast = parse_sql(sql, dialect="mindsdb")
-    expected_ast = CreateKnowledgeBase(
-        name=Identifier("my_knowledge_base"),
-        if_not_exists=False,
-        model=None,
-        storage=None,
-        from_select=None,
-        params={},
-    )
-    assert ast == expected_ast
+    # todo currently this is not supported by the parser
+
+    # sql = """
+    #     CREATE KNOWLEDGE_BASE my_knowledge_base;
+    # """
+    # ast = parse_sql(sql, dialect="mindsdb")
+    # expected_ast = CreateKnowledgeBase(
+    #     name=Identifier("my_knowledge_base"),
+    #     if_not_exists=False,
+    #     model=None,
+    #     storage=None,
+    #     from_select=None,
+    #     params={},
+    # )
+    # assert ast == expected_ast
 
     # create with params
     sql = """

--- a/tests/test_parser/test_mindsdb/test_knowledgebase.py
+++ b/tests/test_parser/test_mindsdb/test_knowledgebase.py
@@ -18,7 +18,7 @@ from mindsdb_sql.parser.ast import (
 )
 
 
-def test_create_knowledeg_base():
+def test_create_knowledge_base():
     # create without select
     sql = """
         CREATE KNOWLEDGE_BASE my_knowledge_base

--- a/tests/test_parser/test_mindsdb/test_knowledgebase.py
+++ b/tests/test_parser/test_mindsdb/test_knowledgebase.py
@@ -94,15 +94,24 @@ def test_create_knowledge_base():
     assert ast == expected_ast
 
     # create without MODEL
-    # TODO: this should be an error
-    # we may allow this in the future when we have a default model
     sql = """
         CREATE KNOWLEDGE_BASE my_knowledge_base
         USING
             STORAGE = my_vector_database.some_table
     """
-    with pytest.raises(Exception):
-        ast = parse_sql(sql, dialect="mindsdb")
+
+    expected_ast = CreateKnowledgeBase(
+        name=Identifier("my_knowledge_base"),
+        if_not_exists=False,
+        model=None,
+        storage=Identifier(parts=["my_vector_database", "some_table"]),
+        from_select=None,
+        params={},
+    )
+
+    ast = parse_sql(sql, dialect="mindsdb")
+
+    assert ast == expected_ast
 
     # create without STORAGE
     sql = """
@@ -136,6 +145,21 @@ def test_create_knowledge_base():
         if_not_exists=True,
         model=Identifier(parts=["mindsdb", "my_embedding_model"]),
         storage=Identifier(parts=["my_vector_database", "some_table"]),
+        from_select=None,
+        params={},
+    )
+    assert ast == expected_ast
+
+    # create without USING ie no storage or model
+    sql = """
+        CREATE KNOWLEDGE_BASE my_knowledge_base
+    """
+    ast = parse_sql(sql, dialect="mindsdb")
+    expected_ast = CreateKnowledgeBase(
+        name=Identifier("my_knowledge_base"),
+        if_not_exists=False,
+        model=None,
+        storage=None,
         from_select=None,
         params={},
     )


### PR DESCRIPTION
Ie user doesn't need to specify a model in query

see:

https://github.com/mindsdb/mindsdb/pull/8464