### PR TITLE
Planner improvements

### DIFF
--- a/mindsdb_sql/__about__.py
+++ b/mindsdb_sql/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'mindsdb_sql'
 __package_name__ = 'mindsdb_sql'
-__version__ = '0.9.0'
+__version__ = '0.10.0'
 __description__ = "Pure python SQL parser"
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'

--- a/mindsdb_sql/parser/ast/select/native_query.py
+++ b/mindsdb_sql/parser/ast/select/native_query.py
@@ -18,10 +18,7 @@ class NativeQuery(ASTNode):
                f'NativeQuery(integration={self.integration.to_string()}, query="{self.query}")'
 
     def get_string(self, *args, **kwargs):
-        alias = ''
-        if self.alias is not None:
-            alias = f'as {self.alias.parts[-1]}'
-        return f'({self.query}) {alias}'
+        return f'({self.query})'
 
     def __repr__(self):
         return f'{self.__class__.__name__}:{self.integration.to_string()} ({self.query})'

--- a/mindsdb_sql/parser/ast/select/native_query.py
+++ b/mindsdb_sql/parser/ast/select/native_query.py
@@ -18,4 +18,10 @@ class NativeQuery(ASTNode):
                f'NativeQuery(integration={self.integration.to_string()}, query="{self.query}")'
 
     def get_string(self, *args, **kwargs):
-        return f'{self.integration.to_string()} ({self.query})'
+        alias = ''
+        if self.alias is not None:
+            alias = f'as {self.alias.parts[-1]}'
+        return f'({self.query}) {alias}'
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}:{self.integration.to_string()} ({self.query})'

--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -1247,8 +1247,7 @@ class MindsDBParser(Parser):
 
     @_('expr',
        'function',
-       'window_function',
-       'case')
+       'window_function')
     def result_column(self, p):
         return p[0]
 
@@ -1446,6 +1445,7 @@ class MindsDBParser(Parser):
        'parameter',
        'constant',
        'latest',
+       'case',
        'function')
     def expr(self, p):
         return p[0]

--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -937,13 +937,15 @@ class MindsDBParser(Parser):
         return {'identifier':p.identifier, 'engine':engine, 'if_not_exists':p.if_not_exists_or_empty}
 
     # UNION / UNION ALL
-    @_('select UNION select')
+    @_('select UNION select',
+       'union UNION select')
     def union(self, p):
-        return Union(left=p.select0, right=p.select1, unique=True)
+        return Union(left=p[0], right=p[2], unique=True)
 
-    @_('select UNION ALL select')
+    @_('select UNION ALL select',
+       'union UNION ALL select',)
     def union(self, p):
-        return Union(left=p.select0, right=p.select1, unique=False)
+        return Union(left=p[0], right=p[3], unique=False)
 
     # tableau
     @_('LPAREN select RPAREN')

--- a/mindsdb_sql/planner/plan_join.py
+++ b/mindsdb_sql/planner/plan_join.py
@@ -24,7 +24,11 @@ class PlanJoin:
     def __init__(self, planner):
         self.planner = planner
 
+        # index to lookup tables
         self.tables_idx = None
+
+        self.step_stack = None
+        self.query_context = {}
 
     def plan(self, query):
         self.tables_idx = {}
@@ -59,7 +63,6 @@ class PlanJoin:
         sub_select = getattr(table, 'sub_select', None)
 
         return TableInfo(integration, table, aliases, conditions=[], sub_select=sub_select)
-
 
     def get_table_for_column(self, column: Identifier):
 
@@ -103,7 +106,7 @@ class PlanJoin:
             raise NotImplementedError()
         return sequence
 
-    def _check_condition_node(self, node):
+    def check_node_condition(self, node):
 
         col_idx = 0
         if len(node.args) == 2:
@@ -139,6 +142,41 @@ class PlanJoin:
         node2._orig_node = node
         table_info.conditions.append(node2)
 
+    def check_query_conditions(self, query):
+        # get conditions for tables
+        binary_ops = []
+
+        def _check_node_condition(node, **kwargs):
+            if isinstance(node, BetweenOperation):
+                self.check_node_condition(node)
+
+            if isinstance(node, BinaryOperation):
+                binary_ops.append(node.op)
+
+                self.check_node_condition(node)
+
+        query_traversal(query.where, _check_node_condition)
+
+        self.query_context['binary_ops'] = binary_ops
+
+    def check_use_limit(self, query_in, join_sequence):
+        # use limit for first table?
+        # if only models
+        use_limit = False
+        if query_in.having is None or query_in.group_by is None and query_in.limit is not None:
+
+            join = None
+            use_limit = True
+            for item in join_sequence:
+                if isinstance(item, TableInfo):
+                    if item.predictor_info is None and item.sub_select is None:
+                        if join is not None:
+                            if join.join_type.upper() != 'LEFT JOIN':
+                                use_limit = False
+                elif isinstance(item, Join):
+                    join = item
+        self.query_context['use_limit'] = use_limit
+
     def plan_join_tables(self, query_in):
         query = copy.deepcopy(query_in)
 
@@ -157,11 +195,10 @@ class PlanJoin:
 
         query_traversal(query.from_table, replace_subselects)
 
-
         # get all join tables, form join sequence
-
         join_sequence = self.get_join_sequence(query.from_table)
 
+        # find tables for identifiers used in query
         def _check_identifiers(node, is_table, **kwargs):
             if not is_table and isinstance(node, Identifier):
                 if len(node.parts) > 1:
@@ -176,143 +213,36 @@ class PlanJoin:
 
         query_traversal(query, _check_identifiers)
 
-
+        # plan all subselects in query
         find_selects = self.planner.get_nested_selects_plan_fnc(self.planner.default_namespace, force=True)
         query_traversal(query.where, find_selects)
 
-        # get conditions for tables
-        binary_ops = []
-
-        def _check_condition(node, **kwargs):
-            if isinstance(node, BetweenOperation):
-                self._check_condition_node(node)
-
-            if isinstance(node, BinaryOperation):
-                binary_ops.append(node.op)
-
-                self._check_condition_node(node)
-
-        query_traversal(query.where, _check_condition)
+        self.check_query_conditions(query)
 
         # workaround for 'model join table': swap tables:
         if len(join_sequence) == 3 and join_sequence[0].predictor_info is not None:
             join_sequence = [join_sequence[1], join_sequence[0], join_sequence[2]]
 
-        # use limit for first table?
-        # if only models
-        use_limit = False
-        if query_in.having is None or query_in.group_by is None and query_in.limit is not None:
-
-            join = None
-            use_limit = True
-            for item in join_sequence:
-                if isinstance(item, TableInfo):
-                    if item.predictor_info is None and item.sub_select is None:
-                        if join is not None:
-                            if join.join_type.upper() != 'LEFT JOIN':
-                                use_limit = False
-                elif isinstance(item, Join):
-                    join = item
+        self.check_use_limit(query_in, join_sequence)
 
         # create plan
         # TODO add optimization: one integration without predictor
 
-        step_stack = []
+        self.step_stack = []
         for item in join_sequence:
             if isinstance(item, TableInfo):
 
                 if item.sub_select is not None:
-                    # is sub select
-                    item.sub_select.alias = None
-                    item.sub_select.parentheses = False
-                    step = self.planner.plan_select(item.sub_select)
-
-                    where = filters_to_bin_op(item.conditions)
-
-                    # apply table alias
-                    query2 = Select(targets=[Star()], where=where)
-                    if item.table.alias is None:
-                        raise PlanningException(f'Subselect in join have to be aliased: {item.sub_select.to_string()}')
-                    table_name = item.table.alias.parts[-1]
-
-                    add_absent_cols = False
-                    if hasattr (item.sub_select, 'from_table') and\
-                         isinstance(item.sub_select.from_table, ast.Data):
-                        add_absent_cols = True
-
-                    step2 = SubSelectStep(query2, step.result, table_name=table_name, add_absent_cols=add_absent_cols)
-                    step2 = self.planner.plan.add_step(step2)
-                    step_stack.append(step2)
+                    self.process_subselect(item)
                 elif item.predictor_info is not None:
-                    if len(step_stack) == 0:
-                        raise NotImplementedError("Predictor can't be first element of join syntax")
-                    if item.predictor_info.get('timeseries'):
-                        raise NotImplementedError("TS predictor is not supported here yet")
-                    data_step = step_stack[-1]
-                    row_dict = None
-                    if item.conditions:
-                        row_dict = {}
-                        for el in item.conditions:
-                            if isinstance(el.args[0], Identifier) and el.op == '=':
-
-                                if isinstance(el.args[1], (Constant, Parameter)):
-                                    row_dict[el.args[0].parts[-1]] = el.args[1].value
-
-                                # exclude condition
-                                item.conditions[0]._orig_node.args = [Constant(0), Constant(0)]
-
-                    predictor_step = self.planner.plan.add_step(ApplyPredictorStep(
-                        namespace=item.integration,
-                        dataframe=data_step.result,
-                        predictor=item.table,
-                        params=query.using,
-                        row_dict=row_dict,
-                    ))
-                    step_stack.append(predictor_step)
+                    self.process_predictor(item, query_in)
                 else:
                     # is table
-                    query2 = Select(from_table=item.table, targets=[Star()])
-                    # parts = tuple(map(str.lower, table_name.parts))
-                    conditions = item.conditions
-                    if 'or' in binary_ops:
-                        # not use conditions
-                        conditions = []
+                    self.process_table(item, query_in)
 
-                    if use_limit:
-                        order_by = None
-                        if query_in.order_by is not None:
-                            order_by = []
-                            # all order column be from this table
-                            for col in query_in.order_by:
-                                if self.get_table_for_column(col.field).table != item.table:
-                                    order_by = False
-                                col = copy.deepcopy(col)
-                                col.field.parts = [col.field.parts[-1]]
-                                order_by.append(col)
-
-                        if order_by is not False:
-                            # copy limit from upper query
-                            query2.limit = query_in.limit
-                            # move offset from upper query
-                            query2.offset = query_in.offset
-                            query_in.offset = None
-                            # copy order
-                            query2.order_by = order_by
-
-                        use_limit = False
-                    for cond in conditions:
-                        if query2.where is not None:
-                            query2.where = BinaryOperation('and', args=[query2.where, cond])
-                        else:
-                            query2.where = cond
-
-                    # step = self.planner.get_integration_select_step(query2)
-                    step = FetchDataframeStep(integration=item.integration, query=query2)
-                    self.planner.plan.add_step(step)
-                    step_stack.append(step)
             elif isinstance(item, Join):
-                step_right = step_stack.pop()
-                step_left = step_stack.pop()
+                step_right = self.step_stack.pop()
+                step_left = self.step_stack.pop()
 
                 new_join = copy.deepcopy(item)
 
@@ -323,7 +253,98 @@ class PlanJoin:
 
                 step = self.planner.plan.add_step(JoinStep(left=step_left.result, right=step_right.result, query=new_join))
 
-                step_stack.append(step)
+                self.step_stack.append(step)
 
         query_in.where = query.where
-        return step_stack.pop()
+        return self.step_stack.pop()
+
+    def process_subselect(self, item):
+        # is sub select
+        item.sub_select.alias = None
+        item.sub_select.parentheses = False
+        step = self.planner.plan_select(item.sub_select)
+
+        where = filters_to_bin_op(item.conditions)
+
+        # apply table alias
+        query2 = Select(targets=[Star()], where=where)
+        if item.table.alias is None:
+            raise PlanningException(f'Subselect in join have to be aliased: {item.sub_select.to_string()}')
+        table_name = item.table.alias.parts[-1]
+
+        add_absent_cols = False
+        if hasattr(item.sub_select, 'from_table') and \
+                isinstance(item.sub_select.from_table, ast.Data):
+            add_absent_cols = True
+
+        step2 = SubSelectStep(query2, step.result, table_name=table_name, add_absent_cols=add_absent_cols)
+        step2 = self.planner.plan.add_step(step2)
+        self.step_stack.append(step2)
+
+    def process_table(self, item, query_in):
+        query2 = Select(from_table=item.table, targets=[Star()])
+        # parts = tuple(map(str.lower, table_name.parts))
+        conditions = item.conditions
+        if 'or' in self.query_context['binary_ops']:
+            # not use conditions
+            conditions = []
+
+        if self.query_context['use_limit']:
+            order_by = None
+            if query_in.order_by is not None:
+                order_by = []
+                # all order column be from this table
+                for col in query_in.order_by:
+                    if self.get_table_for_column(col.field).table != item.table:
+                        order_by = False
+                    col = copy.deepcopy(col)
+                    col.field.parts = [col.field.parts[-1]]
+                    order_by.append(col)
+
+            if order_by is not False:
+                # copy limit from upper query
+                query2.limit = query_in.limit
+                # move offset from upper query
+                query2.offset = query_in.offset
+                query_in.offset = None
+                # copy order
+                query2.order_by = order_by
+
+            self.query_context['use_limit'] = False
+        for cond in conditions:
+            if query2.where is not None:
+                query2.where = BinaryOperation('and', args=[query2.where, cond])
+            else:
+                query2.where = cond
+
+        # step = self.planner.get_integration_select_step(query2)
+        step = FetchDataframeStep(integration=item.integration, query=query2)
+        self.planner.plan.add_step(step)
+        self.step_stack.append(step)
+
+    def process_predictor(self, item, query_in):
+        if len(self.step_stack) == 0:
+            raise NotImplementedError("Predictor can't be first element of join syntax")
+        if item.predictor_info.get('timeseries'):
+            raise NotImplementedError("TS predictor is not supported here yet")
+        data_step = self.step_stack[-1]
+        row_dict = None
+        if item.conditions:
+            row_dict = {}
+            for el in item.conditions:
+                if isinstance(el.args[0], Identifier) and el.op == '=':
+
+                    if isinstance(el.args[1], (Constant, Parameter)):
+                        row_dict[el.args[0].parts[-1]] = el.args[1].value
+
+                    # exclude condition
+                    item.conditions[0]._orig_node.args = [Constant(0), Constant(0)]
+
+        predictor_step = self.planner.plan.add_step(ApplyPredictorStep(
+            namespace=item.integration,
+            dataframe=data_step.result,
+            predictor=item.table,
+            params=query_in.using,
+            row_dict=row_dict,
+        ))
+        self.step_stack.append(predictor_step)

--- a/mindsdb_sql/planner/plan_join.py
+++ b/mindsdb_sql/planner/plan_join.py
@@ -1,10 +1,22 @@
 import copy
+from dataclasses import dataclass, field
+
 from mindsdb_sql.exceptions import PlanningException
 from mindsdb_sql.parser import ast
-from mindsdb_sql.parser.ast import (Select, Identifier, Join, Star, BinaryOperation, Constant, NativeQuery, Parameter)
+from mindsdb_sql.parser.ast import (Select, Identifier, BetweenOperation, Join, Star, BinaryOperation, Constant, NativeQuery, Parameter)
 
 from mindsdb_sql.planner.steps import (FetchDataframeStep, JoinStep, ApplyPredictorStep, SubSelectStep)
 from mindsdb_sql.planner.utils import (query_traversal, filters_to_bin_op)
+
+
+@dataclass
+class TableInfo:
+    integration: str
+    table: Identifier
+    aliases: list[str] = field(default_factory=list)
+    conditions: list = None
+    sub_select: ast.ASTNode = None
+    predictor_info: dict = None
 
 
 class PlanJoin:
@@ -46,13 +58,15 @@ class PlanJoin:
 
         sub_select = getattr(table, 'sub_select', None)
 
-        return dict(
-            integration=integration,
-            table=table,
-            aliases=aliases,
-            conditions=[],
-            sub_select=sub_select,
-        )
+        return TableInfo(integration, table, aliases, conditions=[], sub_select=sub_select)
+
+
+    def get_table_for_column(self, column: Identifier):
+
+        # to lowercase
+        parts = tuple(map(str.lower, column.parts[:-1]))
+        if parts in self.tables_idx:
+            return self.tables_idx[parts]
 
     def get_join_sequence(self, node):
         sequence = []
@@ -60,10 +74,10 @@ class PlanJoin:
             # resolve identifier
 
             table_info = self.resolve_table(node)
-            for alias in table_info['aliases']:
+            for alias in table_info.aliases:
                 self.tables_idx[alias] = table_info
 
-            table_info['predictor_info'] = self.planner.get_predictor(node)
+            table_info.predictor_info = self.planner.get_predictor(node)
 
             sequence.append(table_info)
 
@@ -88,6 +102,42 @@ class PlanJoin:
         else:
             raise NotImplementedError()
         return sequence
+
+    def _check_condition_node(self, node):
+
+        col_idx = 0
+        if len(node.args) == 2:
+            if not isinstance(node.args[col_idx], Identifier):
+                # try to use second arg, could be: 'x'=col
+                col_idx = 1
+
+        # check the case col <condition> constant, col between constant and constant
+        for i, arg in enumerate(node.args):
+            if i == col_idx:
+                if not isinstance(arg, Identifier):
+                    return
+            else:
+                if not isinstance(arg, (Constant, Parameter)):
+                    return
+
+        # checked, find table and store condition
+
+        node2 = copy.deepcopy(node)
+
+        arg1 = node2.args[col_idx]
+
+        if len(arg1.parts) < 2:
+            return
+
+        table_info = self.get_table_for_column(arg1)
+        if table_info is None:
+            raise PlanningException(f'Table not found for identifier: {arg1.to_string()}')
+
+        # keep only column name
+        arg1.parts = [arg1.parts[-1]]
+
+        node2._orig_node = node
+        table_info.conditions.append(node2)
 
     def plan_join_tables(self, query_in):
         query = copy.deepcopy(query_in)
@@ -115,12 +165,12 @@ class PlanJoin:
         def _check_identifiers(node, is_table, **kwargs):
             if not is_table and isinstance(node, Identifier):
                 if len(node.parts) > 1:
-                    parts = tuple(map(str.lower, node.parts[:-1]))
-                    if parts not in self.tables_idx:
+                    table_info = self.get_table_for_column(node)
+                    if table_info is None:
                         raise PlanningException(f'Table not found for identifier: {node.to_string()}')
 
                     # # replace identifies name
-                    col_parts = list(self.tables_idx[parts]['aliases'][-1])
+                    col_parts = list(table_info.aliases[-1])
                     col_parts.append(node.parts[-1])
                     node.parts = col_parts
 
@@ -134,109 +184,130 @@ class PlanJoin:
         binary_ops = []
 
         def _check_condition(node, **kwargs):
+            if isinstance(node, BetweenOperation):
+                self._check_condition_node(node)
+
             if isinstance(node, BinaryOperation):
                 binary_ops.append(node.op)
 
-                node2 = copy.deepcopy(node)
-                arg1, arg2 = node2.args
-                if not isinstance(arg1, Identifier):
-                    arg1, arg2 = arg2, arg1
-
-                if isinstance(arg1, Identifier) and isinstance(arg2, (Constant, Parameter)):
-                    if len(arg1.parts) < 2:
-                        return
-
-                    # to lowercase
-                    parts = tuple(map(str.lower, arg1.parts[:-1]))
-                    if parts not in self.tables_idx:
-                        raise PlanningException(f'Table not found for identifier: {arg1.to_string()}')
-
-                    # keep only column name
-                    arg1.parts = [arg1.parts[-1]]
-
-                    node2._orig_node = node
-                    self.tables_idx[parts]['conditions'].append(node2)
+                self._check_condition_node(node)
 
         query_traversal(query.where, _check_condition)
 
         # workaround for 'model join table': swap tables:
-        if len(join_sequence) == 3 and join_sequence[0]['predictor_info'] is not None:
+        if len(join_sequence) == 3 and join_sequence[0].predictor_info is not None:
             join_sequence = [join_sequence[1], join_sequence[0], join_sequence[2]]
+
+        # use limit for first table?
+        # if only models
+        use_limit = False
+        if query_in.having is None or query_in.group_by is None and query_in.limit is not None:
+
+            join = None
+            use_limit = True
+            for item in join_sequence:
+                if isinstance(item, TableInfo):
+                    if item.predictor_info is None and item.sub_select is None:
+                        if join is not None:
+                            if join.join_type.upper() != 'LEFT JOIN':
+                                use_limit = False
+                elif isinstance(item, Join):
+                    join = item
 
         # create plan
         # TODO add optimization: one integration without predictor
 
         step_stack = []
         for item in join_sequence:
-            if isinstance(item, dict):
-                table_name = item['table']
-                predictor_info = item['predictor_info']
+            if isinstance(item, TableInfo):
 
-                if item['sub_select'] is not None:
+                if item.sub_select is not None:
                     # is sub select
-                    item['sub_select'].alias = None
-                    item['sub_select'].parentheses = False
-                    step = self.planner.plan_select(item['sub_select'])
+                    item.sub_select.alias = None
+                    item.sub_select.parentheses = False
+                    step = self.planner.plan_select(item.sub_select)
 
-                    where = filters_to_bin_op(item['conditions'])
+                    where = filters_to_bin_op(item.conditions)
 
                     # apply table alias
                     query2 = Select(targets=[Star()], where=where)
-                    if item['table'].alias is None:
-                        raise PlanningException(f'Subselect in join have to be aliased: {item["sub_select"].to_string()}')
-                    table_name = item['table'].alias.parts[-1]
+                    if item.table.alias is None:
+                        raise PlanningException(f'Subselect in join have to be aliased: {item.sub_select.to_string()}')
+                    table_name = item.table.alias.parts[-1]
 
                     add_absent_cols = False
-                    if hasattr (item['sub_select'], 'from_table') and\
-                         isinstance(item['sub_select'].from_table, ast.Data):
+                    if hasattr (item.sub_select, 'from_table') and\
+                         isinstance(item.sub_select.from_table, ast.Data):
                         add_absent_cols = True
 
                     step2 = SubSelectStep(query2, step.result, table_name=table_name, add_absent_cols=add_absent_cols)
                     step2 = self.planner.plan.add_step(step2)
                     step_stack.append(step2)
-                elif predictor_info is not None:
+                elif item.predictor_info is not None:
                     if len(step_stack) == 0:
                         raise NotImplementedError("Predictor can't be first element of join syntax")
-                    if predictor_info.get('timeseries'):
+                    if item.predictor_info.get('timeseries'):
                         raise NotImplementedError("TS predictor is not supported here yet")
                     data_step = step_stack[-1]
                     row_dict = None
-                    if item['conditions']:
+                    if item.conditions:
                         row_dict = {}
-                        for el in item['conditions']:
+                        for el in item.conditions:
                             if isinstance(el.args[0], Identifier) and el.op == '=':
 
                                 if isinstance(el.args[1], (Constant, Parameter)):
                                     row_dict[el.args[0].parts[-1]] = el.args[1].value
 
                                 # exclude condition
-                                item['conditions'][0]._orig_node.args = [Constant(0), Constant(0)]
+                                item.conditions[0]._orig_node.args = [Constant(0), Constant(0)]
 
                     predictor_step = self.planner.plan.add_step(ApplyPredictorStep(
-                        namespace=item['integration'],
+                        namespace=item.integration,
                         dataframe=data_step.result,
-                        predictor=table_name,
+                        predictor=item.table,
                         params=query.using,
                         row_dict=row_dict,
                     ))
                     step_stack.append(predictor_step)
                 else:
                     # is table
-                    query2 = Select(from_table=table_name, targets=[Star()])
+                    query2 = Select(from_table=item.table, targets=[Star()])
                     # parts = tuple(map(str.lower, table_name.parts))
-                    conditions = item['conditions']
+                    conditions = item.conditions
                     if 'or' in binary_ops:
                         # not use conditions
                         conditions = []
 
+                    if use_limit:
+                        order_by = None
+                        if query_in.order_by is not None:
+                            order_by = []
+                            # all order column be from this table
+                            for col in query_in.order_by:
+                                if self.get_table_for_column(col.field).table != item.table:
+                                    order_by = False
+                                col = copy.deepcopy(col)
+                                col.field.parts = [col.field.parts[-1]]
+                                order_by.append(col)
+
+                        if order_by is not False:
+                            # copy limit from upper query
+                            query2.limit = query_in.limit
+                            # move offset from upper query
+                            query2.offset = query_in.offset
+                            query_in.offset = None
+                            # copy order
+                            query2.order_by = order_by
+
+                        use_limit = False
                     for cond in conditions:
                         if query2.where is not None:
                             query2.where = BinaryOperation('and', args=[query2.where, cond])
                         else:
                             query2.where = cond
 
-                    # TODO use self.get_integration_select_step(query2)
-                    step = FetchDataframeStep(integration=item['integration'], query=query2)
+                    # step = self.planner.get_integration_select_step(query2)
+                    step = FetchDataframeStep(integration=item.integration, query=query2)
                     self.planner.plan.add_step(step)
                     step_stack.append(step)
             elif isinstance(item, Join):

--- a/mindsdb_sql/planner/plan_join.py
+++ b/mindsdb_sql/planner/plan_join.py
@@ -1,3 +1,4 @@
+from typing import List
 import copy
 from dataclasses import dataclass, field
 
@@ -14,8 +15,8 @@ from mindsdb_sql.planner.plan_join_ts import PlanJoinTSPredictorQuery
 class TableInfo:
     integration: str
     table: Identifier
-    aliases: list[str] = field(default_factory=list)
-    conditions: list = None
+    aliases: List[str] = field(default_factory=List)
+    conditions: List = None
     sub_select: ast.ASTNode = None
     predictor_info: dict = None
 

--- a/mindsdb_sql/planner/plan_join.py
+++ b/mindsdb_sql/planner/plan_join.py
@@ -1,0 +1,258 @@
+import copy
+from mindsdb_sql.exceptions import PlanningException
+from mindsdb_sql.parser import ast
+from mindsdb_sql.parser.ast import (Select, Identifier, Join, Star, BinaryOperation, Constant, NativeQuery, Parameter)
+
+from mindsdb_sql.planner.steps import (FetchDataframeStep, JoinStep, ApplyPredictorStep, SubSelectStep)
+from mindsdb_sql.planner.utils import (query_traversal, filters_to_bin_op)
+
+
+class PlanJoin:
+
+    def __init__(self, planner):
+        self.planner = planner
+
+        self.tables_idx = None
+
+    def plan(self, query):
+        self.tables_idx = {}
+        return self.plan_join_tables(query)
+
+    def resolve_table(self, table):
+        # gets integration for table and name to access to it
+        table = copy.deepcopy(table)
+        # get possible table aliases
+        aliases = []
+        if table.alias is not None:
+            # to lowercase
+            parts = tuple(map(str.lower, table.alias.parts))
+            aliases.append(parts)
+        else:
+            for i in range(0, len(table.parts)):
+                parts = table.parts[i:]
+                parts = tuple(map(str.lower, parts))
+                aliases.append(parts)
+
+        # try to use default namespace
+        integration = self.planner.default_namespace
+        if len(table.parts) > 0:
+            if table.parts[0] in self.planner.databases:
+                integration = table.parts.pop(0)
+            else:
+                integration = self.planner.default_namespace
+
+        if integration is None and not hasattr(table, 'sub_select'):
+            raise PlanningException(f'Integration not found for: {table}')
+
+        sub_select = getattr(table, 'sub_select', None)
+
+        return dict(
+            integration=integration,
+            table=table,
+            aliases=aliases,
+            conditions=[],
+            sub_select=sub_select,
+        )
+
+    def get_join_sequence(self, node):
+        sequence = []
+        if isinstance(node, Identifier):
+            # resolve identifier
+
+            table_info = self.resolve_table(node)
+            for alias in table_info['aliases']:
+                self.tables_idx[alias] = table_info
+
+            table_info['predictor_info'] = self.planner.get_predictor(node)
+
+            sequence.append(table_info)
+
+        elif isinstance(node, Join):
+            # create sequence: 1)table1, 2)table2, 3)join 1 2, 4)table 3, 5)join 3 4
+
+            # put all tables before
+            sequence2 = self.get_join_sequence(node.left)
+            for item in sequence2:
+                sequence.append(item)
+
+            sequence2 = self.get_join_sequence(node.right)
+            if len(sequence2) != 1:
+                raise PlanningException('Unexpected join nesting behavior')
+
+            # put next table
+            sequence.append(sequence2[0])
+
+            # put join
+            sequence.append(node)
+
+        else:
+            raise NotImplementedError()
+        return sequence
+
+    def plan_join_tables(self, query_in):
+        query = copy.deepcopy(query_in)
+
+        # replace sub selects, with identifiers with links to original selects
+        def replace_subselects(node, **args):
+            if isinstance(node, Select) or isinstance(node, NativeQuery) or isinstance(node, ast.Data):
+                name = f't_{id(node)}'
+                node2 = Identifier(name, alias=node.alias)
+
+                # save in attribute
+                if isinstance(node, NativeQuery) or isinstance(node, ast.Data):
+                    # wrap to select
+                    node = Select(targets=[Star()], from_table=node)
+                node2.sub_select = node
+                return node2
+
+        query_traversal(query.from_table, replace_subselects)
+
+
+        # get all join tables, form join sequence
+
+        join_sequence = self.get_join_sequence(query.from_table)
+
+        def _check_identifiers(node, is_table, **kwargs):
+            if not is_table and isinstance(node, Identifier):
+                if len(node.parts) > 1:
+                    parts = tuple(map(str.lower, node.parts[:-1]))
+                    if parts not in self.tables_idx:
+                        raise PlanningException(f'Table not found for identifier: {node.to_string()}')
+
+                    # # replace identifies name
+                    col_parts = list(self.tables_idx[parts]['aliases'][-1])
+                    col_parts.append(node.parts[-1])
+                    node.parts = col_parts
+
+        query_traversal(query, _check_identifiers)
+
+
+        find_selects = self.planner.get_nested_selects_plan_fnc(self.planner.default_namespace, force=True)
+        query_traversal(query.where, find_selects)
+
+        # get conditions for tables
+        binary_ops = []
+
+        def _check_condition(node, **kwargs):
+            if isinstance(node, BinaryOperation):
+                binary_ops.append(node.op)
+
+                node2 = copy.deepcopy(node)
+                arg1, arg2 = node2.args
+                if not isinstance(arg1, Identifier):
+                    arg1, arg2 = arg2, arg1
+
+                if isinstance(arg1, Identifier) and isinstance(arg2, (Constant, Parameter)):
+                    if len(arg1.parts) < 2:
+                        return
+
+                    # to lowercase
+                    parts = tuple(map(str.lower, arg1.parts[:-1]))
+                    if parts not in self.tables_idx:
+                        raise PlanningException(f'Table not found for identifier: {arg1.to_string()}')
+
+                    # keep only column name
+                    arg1.parts = [arg1.parts[-1]]
+
+                    node2._orig_node = node
+                    self.tables_idx[parts]['conditions'].append(node2)
+
+        query_traversal(query.where, _check_condition)
+
+        # workaround for 'model join table': swap tables:
+        if len(join_sequence) == 3 and join_sequence[0]['predictor_info'] is not None:
+            join_sequence = [join_sequence[1], join_sequence[0], join_sequence[2]]
+
+        # create plan
+        # TODO add optimization: one integration without predictor
+
+        step_stack = []
+        for item in join_sequence:
+            if isinstance(item, dict):
+                table_name = item['table']
+                predictor_info = item['predictor_info']
+
+                if item['sub_select'] is not None:
+                    # is sub select
+                    item['sub_select'].alias = None
+                    item['sub_select'].parentheses = False
+                    step = self.planner.plan_select(item['sub_select'])
+
+                    where = filters_to_bin_op(item['conditions'])
+
+                    # apply table alias
+                    query2 = Select(targets=[Star()], where=where)
+                    if item['table'].alias is None:
+                        raise PlanningException(f'Subselect in join have to be aliased: {item["sub_select"].to_string()}')
+                    table_name = item['table'].alias.parts[-1]
+
+                    add_absent_cols = False
+                    if hasattr (item['sub_select'], 'from_table') and\
+                         isinstance(item['sub_select'].from_table, ast.Data):
+                        add_absent_cols = True
+
+                    step2 = SubSelectStep(query2, step.result, table_name=table_name, add_absent_cols=add_absent_cols)
+                    step2 = self.planner.plan.add_step(step2)
+                    step_stack.append(step2)
+                elif predictor_info is not None:
+                    if len(step_stack) == 0:
+                        raise NotImplementedError("Predictor can't be first element of join syntax")
+                    if predictor_info.get('timeseries'):
+                        raise NotImplementedError("TS predictor is not supported here yet")
+                    data_step = step_stack[-1]
+                    row_dict = None
+                    if item['conditions']:
+                        row_dict = {}
+                        for el in item['conditions']:
+                            if isinstance(el.args[0], Identifier) and el.op == '=':
+
+                                if isinstance(el.args[1], (Constant, Parameter)):
+                                    row_dict[el.args[0].parts[-1]] = el.args[1].value
+
+                                # exclude condition
+                                item['conditions'][0]._orig_node.args = [Constant(0), Constant(0)]
+
+                    predictor_step = self.planner.plan.add_step(ApplyPredictorStep(
+                        namespace=item['integration'],
+                        dataframe=data_step.result,
+                        predictor=table_name,
+                        params=query.using,
+                        row_dict=row_dict,
+                    ))
+                    step_stack.append(predictor_step)
+                else:
+                    # is table
+                    query2 = Select(from_table=table_name, targets=[Star()])
+                    # parts = tuple(map(str.lower, table_name.parts))
+                    conditions = item['conditions']
+                    if 'or' in binary_ops:
+                        # not use conditions
+                        conditions = []
+
+                    for cond in conditions:
+                        if query2.where is not None:
+                            query2.where = BinaryOperation('and', args=[query2.where, cond])
+                        else:
+                            query2.where = cond
+
+                    # TODO use self.get_integration_select_step(query2)
+                    step = FetchDataframeStep(integration=item['integration'], query=query2)
+                    self.planner.plan.add_step(step)
+                    step_stack.append(step)
+            elif isinstance(item, Join):
+                step_right = step_stack.pop()
+                step_left = step_stack.pop()
+
+                new_join = copy.deepcopy(item)
+
+                # TODO
+                new_join.left = Identifier('tab1')
+                new_join.right = Identifier('tab2')
+                new_join.implicit = False
+
+                step = self.planner.plan.add_step(JoinStep(left=step_left.result, right=step_right.result, query=new_join))
+
+                step_stack.append(step)
+
+        query_in.where = query.where
+        return step_stack.pop()

--- a/mindsdb_sql/planner/plan_join_ts.py
+++ b/mindsdb_sql/planner/plan_join_ts.py
@@ -1,0 +1,355 @@
+import copy
+
+from mindsdb_sql import Latest, OrderBy, NullConstant
+from mindsdb_sql.exceptions import PlanningException
+from mindsdb_sql.parser.ast import (Select, Identifier, BetweenOperation, Join, Star, BinaryOperation, Constant)
+from mindsdb_sql.planner import utils
+from mindsdb_sql.planner.steps import (JoinStep, LimitOffsetStep, MultipleSteps, MapReduceStep,
+                                       ApplyTimeseriesPredictorStep)
+from mindsdb_sql.planner.ts_utils import validate_ts_where_condition, find_time_filter, replace_time_filter, \
+    find_and_remove_time_filter, recursively_check_join_identifiers_for_ambiguity
+from mindsdb_sql.planner.utils import (query_traversal, )
+
+
+class PlanJoinTSPredictorQuery:
+
+    def __init__(self, planner):
+        self.planner = planner
+
+    def adapt_dbt_query(self, query, integration):
+        orig_query = query
+
+        join = query.from_table
+        join_left = join.left
+
+        # dbt query.
+
+        # move latest into subquery
+        moved_conditions = []
+
+        def move_latest(node, **kwargs):
+            if isinstance(node, BinaryOperation):
+                if Latest() in node.args:
+                    for arg in node.args:
+                        if isinstance(arg, Identifier):
+                            # remove table alias
+                            arg.parts = [arg.parts[-1]]
+                    moved_conditions.append(node)
+
+        query_traversal(query.where, move_latest)
+
+        # TODO make project step from query.target
+
+        # TODO support complex query. Only one table is supported at the moment.
+        # if not isinstance(join_left.from_table, Identifier):
+        #     raise PlanningException(f'Statement not supported: {query.to_string()}')
+
+        # move properties to upper query
+        query = join_left
+
+        if query.from_table.alias is not None:
+            table_alias = [query.from_table.alias.parts[0]]
+        else:
+            table_alias = query.from_table.parts
+
+        # add latest to query.where
+        for cond in moved_conditions:
+            if query.where is not None:
+                query.where = BinaryOperation('and', args=[query.where, cond])
+            else:
+                query.where = cond
+
+        def add_aliases(node, is_table, **kwargs):
+            if not is_table and isinstance(node, Identifier):
+                if len(node.parts) == 1:
+                    # add table alias to field
+                    node.parts = table_alias + node.parts
+
+        query_traversal(query.where, add_aliases)
+
+        if isinstance(query.from_table, Identifier):
+            # DBT workaround: allow use tables without integration.
+            #   if table.part[0] not in integration - take integration name from create table command
+            if (
+                integration is not None
+                and query.from_table.parts[0] not in self.planner.databases
+            ):
+                # add integration name to table
+                query.from_table.parts.insert(0, integration)
+
+        join_left = join_left.from_table
+
+        if orig_query.limit is not None:
+            if query.limit is None or query.limit.value > orig_query.limit.value:
+                query.limit = orig_query.limit
+        query.parentheses = False
+        query.alias = None
+
+        return query, join_left
+
+    def get_aliased_fields(self, targets):
+        # get aliases from select target
+        aliased_fields = {}
+        for target in targets:
+            if target.alias is not None:
+                aliased_fields[target.alias.to_string()] = target
+        return aliased_fields
+
+    def plan_fetch_timeseries_partitions(self, query, table, predictor_group_by_names):
+        targets = [
+            Identifier(column)
+            for column in predictor_group_by_names
+        ]
+
+        query = Select(
+            distinct=True,
+            targets=targets,
+            from_table=table,
+            where=query.where,
+            modifiers=query.modifiers,
+        )
+        select_step = self.planner.plan_integration_select(query)
+        return select_step
+
+    def plan(self, query, integration=None):
+        # integration is for dbt only
+
+        join = query.from_table
+        join_left = join.left
+        join_right = join.right
+
+        predictor_is_left = False
+        if self.planner.is_predictor(join_left):
+            # predictor is in the left, put it in the right
+            join_left, join_right = join_right, join_left
+            predictor_is_left = True
+
+        if self.planner.is_predictor(join_left):
+            # in the left is also predictor
+            raise PlanningException(f'Can\'t join two predictors {join_left} and {join_left}')
+
+        orig_query = query
+        # dbt query?
+        if isinstance(join_left, Select) and isinstance(join_left.from_table, Identifier):
+            query, join_left = self.adapt_dbt_query(query, integration)
+
+        predictor_namespace, predictor = self.planner.get_predictor_namespace_and_name_from_identifier(join_right)
+        table = join_left
+
+        aliased_fields = self.get_aliased_fields(query.targets)
+
+        recursively_check_join_identifiers_for_ambiguity(query.where)
+        recursively_check_join_identifiers_for_ambiguity(query.group_by, aliased_fields=aliased_fields)
+        recursively_check_join_identifiers_for_ambiguity(query.having)
+        recursively_check_join_identifiers_for_ambiguity(query.order_by, aliased_fields=aliased_fields)
+
+        predictor_steps = self.plan_timeseries_predictor(query, table, predictor_namespace, predictor)
+
+        # add join
+        # Update reference
+
+        left = Identifier(predictor_steps['predictor'].result.ref_name)
+        right = Identifier(predictor_steps['data'].result.ref_name)
+
+        if not predictor_is_left:
+            # swap join
+            left, right = right, left
+        new_join = Join(left=left, right=right, join_type=join.join_type)
+
+        left = predictor_steps['predictor'].result
+        right = predictor_steps['data'].result
+        if not predictor_is_left:
+            # swap join
+            left, right = right, left
+
+        last_step = self.planner.plan.add_step(JoinStep(left=left, right=right, query=new_join))
+
+        # limit from timeseries
+        if predictor_steps.get('saved_limit'):
+            last_step = self.planner.plan.add_step(LimitOffsetStep(dataframe=last_step.result,
+                                                           limit=predictor_steps['saved_limit']))
+
+        return self.planner.plan_project(orig_query, last_step.result)
+
+    def plan_timeseries_predictor(self, query, table, predictor_namespace, predictor):
+
+        predictor_metadata = self.planner.get_predictor(predictor)
+
+        predictor_time_column_name = predictor_metadata['order_by_column']
+        predictor_group_by_names = predictor_metadata['group_by_columns']
+        if predictor_group_by_names is None:
+            predictor_group_by_names = []
+        predictor_window = predictor_metadata['window']
+
+        if query.order_by:
+            raise PlanningException(
+                f'Can\'t provide ORDER BY to time series predictor, it will be taken from predictor settings. Found: {query.order_by}')
+
+        saved_limit = None
+        if query.limit is not None:
+            saved_limit = query.limit.value
+
+        if query.group_by or query.having or query.offset:
+            raise PlanningException(f'Unsupported query to timeseries predictor: {str(query)}')
+
+        allowed_columns = [predictor_time_column_name.lower()]
+        if len(predictor_group_by_names) > 0:
+            allowed_columns += [i.lower() for i in predictor_group_by_names]
+        validate_ts_where_condition(query.where, allowed_columns=allowed_columns)
+
+        time_filter = find_time_filter(query.where, time_column_name=predictor_time_column_name)
+
+        order_by = [OrderBy(Identifier(parts=[predictor_time_column_name]), direction='DESC')]
+
+        preparation_where = copy.deepcopy(query.where)
+
+        query_modifiers = query.modifiers
+
+        # add {order_by_field} is not null
+        def add_order_not_null(condition):
+            order_field_not_null = BinaryOperation(op='is not', args=[
+                Identifier(parts=[predictor_time_column_name]),
+                NullConstant()
+            ])
+            if condition is not None:
+                condition = BinaryOperation(op='and', args=[
+                    condition,
+                    order_field_not_null
+                ])
+            else:
+                condition = order_field_not_null
+            return condition
+
+        preparation_where2 = copy.deepcopy(preparation_where)
+        preparation_where = add_order_not_null(preparation_where)
+
+        # Obtain integration selects
+        if isinstance(time_filter, BetweenOperation):
+            between_from = time_filter.args[1]
+            preparation_time_filter = BinaryOperation('<', args=[Identifier(predictor_time_column_name), between_from])
+            preparation_where2 = replace_time_filter(preparation_where2, time_filter, preparation_time_filter)
+            integration_select_1 = Select(targets=[Star()],
+                                        from_table=table,
+                                        where=add_order_not_null(preparation_where2),
+                                        modifiers=query_modifiers,
+                                        order_by=order_by,
+                                        limit=Constant(predictor_window))
+
+            integration_select_2 = Select(targets=[Star()],
+                                          from_table=table,
+                                          where=preparation_where,
+                                          modifiers=query_modifiers,
+                                          order_by=order_by)
+
+            integration_selects = [integration_select_1, integration_select_2]
+        elif isinstance(time_filter, BinaryOperation) and time_filter.op == '>' and time_filter.args[1] == Latest():
+            integration_select = Select(targets=[Star()],
+                                        from_table=table,
+                                        where=preparation_where,
+                                        modifiers=query_modifiers,
+                                        order_by=order_by,
+                                        limit=Constant(predictor_window),
+                                        )
+            integration_select.where = find_and_remove_time_filter(integration_select.where, time_filter)
+            integration_selects = [integration_select]
+        elif isinstance(time_filter, BinaryOperation) and time_filter.op == '=' and time_filter.args[1] == Latest():
+            integration_select = Select(targets=[Star()],
+                                        from_table=table,
+                                        where=preparation_where,
+                                        modifiers=query_modifiers,
+                                        order_by=order_by,
+                                        limit=Constant(predictor_window),
+                                        )
+            integration_select.where = find_and_remove_time_filter(integration_select.where, time_filter)
+            integration_selects = [integration_select]
+        elif isinstance(time_filter, BinaryOperation) and time_filter.op in ('>', '>='):
+            time_filter_date = time_filter.args[1]
+            preparation_time_filter_op = {'>': '<=', '>=': '<'}[time_filter.op]
+
+            preparation_time_filter = BinaryOperation(preparation_time_filter_op, args=[Identifier(predictor_time_column_name), time_filter_date])
+            preparation_where2 = replace_time_filter(preparation_where2, time_filter, preparation_time_filter)
+            integration_select_1 = Select(targets=[Star()],
+                                          from_table=table,
+                                          where=add_order_not_null(preparation_where2),
+                                          modifiers=query_modifiers,
+                                          order_by=order_by,
+                                          limit=Constant(predictor_window))
+
+            integration_select_2 = Select(targets=[Star()],
+                                          from_table=table,
+                                          where=preparation_where,
+                                          modifiers=query_modifiers,
+                                          order_by=order_by)
+
+            integration_selects = [integration_select_1, integration_select_2]
+        else:
+            integration_select = Select(targets=[Star()],
+                                        from_table=table,
+                                        where=preparation_where,
+                                        modifiers=query_modifiers,
+                                        order_by=order_by,
+                                        )
+            integration_selects = [integration_select]
+
+        if len(predictor_group_by_names) == 0:
+            # ts query without grouping
+            # one or multistep
+            if len(integration_selects) == 1:
+                select_partition_step = self.planner.get_integration_select_step(integration_selects[0])
+            else:
+                select_partition_step = MultipleSteps(
+                    steps=[self.planner.get_integration_select_step(s) for s in integration_selects], reduce='union')
+
+            # fetch data step
+            data_step = self.planner.plan.add_step(select_partition_step)
+        else:
+            # inject $var to queries
+            for integration_select in integration_selects:
+                condition = integration_select.where
+                for num, column in enumerate(predictor_group_by_names):
+                    cond = BinaryOperation('=', args=[Identifier(column), Constant(f'$var[{column}]')])
+
+                    # join to main condition
+                    if condition is None:
+                        condition = cond
+                    else:
+                        condition = BinaryOperation('and', args=[condition, cond])
+
+                integration_select.where = condition
+            # one or multistep
+            if len(integration_selects) == 1:
+                select_partition_step = self.planner.get_integration_select_step(integration_selects[0])
+            else:
+                select_partition_step = MultipleSteps(
+                    steps=[self.planner.get_integration_select_step(s) for s in integration_selects], reduce='union')
+
+            # get groping values
+            no_time_filter_query = copy.deepcopy(query)
+            no_time_filter_query.where = find_and_remove_time_filter(no_time_filter_query.where, time_filter)
+            select_partitions_step = self.plan_fetch_timeseries_partitions(no_time_filter_query, table, predictor_group_by_names)
+
+            # sub-query by every grouping value
+            map_reduce_step = self.planner.plan.add_step(MapReduceStep(values=select_partitions_step.result, reduce='union', step=select_partition_step))
+            data_step = map_reduce_step
+
+        predictor_identifier = utils.get_predictor_name_identifier(predictor)
+
+        params = None
+        if query.using is not None:
+            params = query.using
+        predictor_step = self.planner.plan.add_step(
+            ApplyTimeseriesPredictorStep(
+                output_time_filter=time_filter,
+                namespace=predictor_namespace,
+                dataframe=data_step.result,
+                predictor=predictor_identifier,
+                params=params,
+            )
+        )
+
+        return {
+            'predictor': predictor_step,
+            'data': data_step,
+            'saved_limit': saved_limit,
+        }
+

--- a/mindsdb_sql/planner/query_planner.py
+++ b/mindsdb_sql/planner/query_planner.py
@@ -164,7 +164,10 @@ class QueryPlanner:
         query_traversal(query, _prepare_integration_select)
 
     def get_integration_select_step(self, select):
-        integration_name, table = self.resolve_database_table(select.from_table)
+        if isinstance(select.from_table, NativeQuery):
+            integration_name = select.from_table.integration.parts[-1]
+        else:
+            integration_name, table = self.resolve_database_table(select.from_table)
 
         fetch_df_select = copy.deepcopy(select)
         self.prepare_integration_select(integration_name, fetch_df_select)

--- a/mindsdb_sql/planner/query_planner.py
+++ b/mindsdb_sql/planner/query_planner.py
@@ -924,7 +924,7 @@ class QueryPlanner():
         ):
             query2 = copy.deepcopy(query)
             query2.from_table = None
-            sup_select = QueryStep(query2, join_step.result)
+            sup_select = QueryStep(query2, from_table=join_step.result)
             self.plan.add_step(sup_select)
             return sup_select
         return join_step

--- a/mindsdb_sql/planner/query_planner.py
+++ b/mindsdb_sql/planner/query_planner.py
@@ -911,28 +911,12 @@ class QueryPlanner():
         plan_join = PlanJoin(self)
         join_step = plan_join.plan(query)
 
-        if (
-            query.group_by is not None
-            or query.order_by is not None
-            or query.having is not None
-            or query.distinct is True
-            or query.where is not None
-            or query.limit is not None
-            or query.offset is not None
-            or len(query.targets) != 1
-            or not isinstance(query.targets[0], Star)
-        ):
-            query2 = copy.deepcopy(query)
-            query2.from_table = None
-            sup_select = QueryStep(query2, from_table=join_step.result)
-            self.plan.add_step(sup_select)
-            return sup_select
-        return join_step
-
         # FIXME: Tableau workaround, INFORMATION_SCHEMA with Where
         # if isinstance(join.right, Identifier) \
         #         and self.resolve_database_table(join.right)[0] == 'INFORMATION_SCHEMA':
         #     pass
+
+        return join_step
 
 
     def plan_create_table(self, query):

--- a/mindsdb_sql/planner/query_planner.py
+++ b/mindsdb_sql/planner/query_planner.py
@@ -1295,10 +1295,14 @@ class QueryPlanner():
         return prev_step
 
     def plan_union(self, query):
-        query1 = self.plan_select(query.left)
-        query2 = self.plan_select(query.right)
+        if isinstance(query.left, Union):
+            step1 = self.plan_union(query.left)
+        else:
+            # it is select
+            step1 = self.plan_select(query.left)
+        step2 = self.plan_select(query.right)
 
-        return self.plan.add_step(UnionStep(left=query1.result, right=query2.result, unique=query.unique))
+        return self.plan.add_step(UnionStep(left=step1.result, right=step2.result, unique=query.unique))
 
     # method for compatibility
     def from_query(self, query=None):

--- a/mindsdb_sql/planner/steps.py
+++ b/mindsdb_sql/planner/steps.py
@@ -49,28 +49,28 @@ class ProjectStep(PlanStep):
             self.references.append(dataframe)
 
 
-class FilterStep(PlanStep):
-    """Filters some dataframe according to a query"""
-    def __init__(self, dataframe, query, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.dataframe = dataframe
-        self.query = query
+# class FilterStep(PlanStep):
+#     """Filters some dataframe according to a query"""
+#     def __init__(self, dataframe, query, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         self.dataframe = dataframe
+#         self.query = query
+#
+#         if isinstance(dataframe, Result):
+#             self.references.append(dataframe)
 
-        if isinstance(dataframe, Result):
-            self.references.append(dataframe)
 
-
-class GroupByStep(PlanStep):
-    """Groups output by columns and computes aggregation functions"""
-
-    def __init__(self, dataframe, columns, targets, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.dataframe = dataframe
-        self.columns = columns
-        self.targets = targets
-
-        if isinstance(dataframe, Result):
-            self.references.append(dataframe)
+# class GroupByStep(PlanStep):
+#     """Groups output by columns and computes aggregation functions"""
+#
+#     def __init__(self, dataframe, columns, targets, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         self.dataframe = dataframe
+#         self.columns = columns
+#         self.targets = targets
+#
+#         if isinstance(dataframe, Result):
+#             self.references.append(dataframe)
 
 
 class JoinStep(PlanStep):
@@ -103,16 +103,16 @@ class UnionStep(PlanStep):
             self.references.append(right)
 
 
-class OrderByStep(PlanStep):
-    """Applies sorting to a dataframe"""
-
-    def __init__(self, dataframe, order_by, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.dataframe = dataframe
-        self.order_by = order_by
-
-        if isinstance(dataframe, Result):
-            self.references.append(dataframe)
+# class OrderByStep(PlanStep):
+#     """Applies sorting to a dataframe"""
+#
+#     def __init__(self, dataframe, order_by, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         self.dataframe = dataframe
+#         self.order_by = order_by
+#
+#         if isinstance(dataframe, Result):
+#             self.references.append(dataframe)
 
 
 class LimitOffsetStep(PlanStep):
@@ -252,6 +252,14 @@ class SubSelectStep(PlanStep):
         self.dataframe = dataframe
         self.table_name = table_name
         self.add_absent_cols = add_absent_cols
+
+
+class QueryStep(PlanStep):
+    def __init__(self, query, dataframe, *args, **kwargs):
+        """Performs select from dataframe"""
+        super().__init__(*args, **kwargs)
+        self.query = query
+        self.dataframe = dataframe
 
 
 class DataStep(PlanStep):

--- a/mindsdb_sql/planner/steps.py
+++ b/mindsdb_sql/planner/steps.py
@@ -48,29 +48,29 @@ class ProjectStep(PlanStep):
         if isinstance(dataframe, Result):
             self.references.append(dataframe)
 
+# TODO remove
+class FilterStep(PlanStep):
+    """Filters some dataframe according to a query"""
+    def __init__(self, dataframe, query, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.dataframe = dataframe
+        self.query = query
 
-# class FilterStep(PlanStep):
-#     """Filters some dataframe according to a query"""
-#     def __init__(self, dataframe, query, *args, **kwargs):
-#         super().__init__(*args, **kwargs)
-#         self.dataframe = dataframe
-#         self.query = query
-#
-#         if isinstance(dataframe, Result):
-#             self.references.append(dataframe)
+        if isinstance(dataframe, Result):
+            self.references.append(dataframe)
 
+# TODO remove
+class GroupByStep(PlanStep):
+    """Groups output by columns and computes aggregation functions"""
 
-# class GroupByStep(PlanStep):
-#     """Groups output by columns and computes aggregation functions"""
-#
-#     def __init__(self, dataframe, columns, targets, *args, **kwargs):
-#         super().__init__(*args, **kwargs)
-#         self.dataframe = dataframe
-#         self.columns = columns
-#         self.targets = targets
-#
-#         if isinstance(dataframe, Result):
-#             self.references.append(dataframe)
+    def __init__(self, dataframe, columns, targets, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.dataframe = dataframe
+        self.columns = columns
+        self.targets = targets
+
+        if isinstance(dataframe, Result):
+            self.references.append(dataframe)
 
 
 class JoinStep(PlanStep):
@@ -102,17 +102,17 @@ class UnionStep(PlanStep):
         if isinstance(right, Result):
             self.references.append(right)
 
+# TODO remove
+class OrderByStep(PlanStep):
+    """Applies sorting to a dataframe"""
 
-# class OrderByStep(PlanStep):
-#     """Applies sorting to a dataframe"""
-#
-#     def __init__(self, dataframe, order_by, *args, **kwargs):
-#         super().__init__(*args, **kwargs)
-#         self.dataframe = dataframe
-#         self.order_by = order_by
-#
-#         if isinstance(dataframe, Result):
-#             self.references.append(dataframe)
+    def __init__(self, dataframe, order_by, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.dataframe = dataframe
+        self.order_by = order_by
+
+        if isinstance(dataframe, Result):
+            self.references.append(dataframe)
 
 
 class LimitOffsetStep(PlanStep):
@@ -255,11 +255,11 @@ class SubSelectStep(PlanStep):
 
 
 class QueryStep(PlanStep):
-    def __init__(self, query, dataframe, *args, **kwargs):
-        """Performs select from dataframe"""
+    def __init__(self, query, from_table=None, *args, **kwargs):
+        """Performs query using injected dataframe"""
         super().__init__(*args, **kwargs)
         self.query = query
-        self.dataframe = dataframe
+        self.from_table = from_table
 
 
 class DataStep(PlanStep):

--- a/mindsdb_sql/planner/utils.py
+++ b/mindsdb_sql/planner/utils.py
@@ -126,7 +126,10 @@ def query_traversal(node, callback, is_table=False, is_target=False, parent_quer
         array = []
         for node2 in node.targets:
             node_out = query_traversal(node2, callback, parent_query=node, is_target=True) or node2
-            array.append(node_out)
+            if isinstance(node_out, list):
+                array.extend(node_out)
+            else:
+                array.append(node_out)
         node.targets = array
 
         if node.cte is not None:

--- a/mindsdb_sql/planner/utils.py
+++ b/mindsdb_sql/planner/utils.py
@@ -293,6 +293,20 @@ def query_traversal(node, callback, is_table=False, is_target=False, parent_quer
             if node_out is not None:
                 node.field = node_out
 
+    elif isinstance(node, ast.Case):
+        rules = []
+        for condition, result in node.rules:
+            condition2 = query_traversal(condition, callback, parent_query=parent_query)
+            result2 = query_traversal(result, callback, parent_query=parent_query)
+
+            condition = condition if condition2 is None else condition2
+            result = result if result2 is None else result2
+            rules.append([condition, result])
+        node.rules = rules
+        default = query_traversal(node.default, callback, parent_query=parent_query)
+        if default is not None:
+            node.default = default
+
     elif isinstance(node, list):
         array = []
         for node2 in node:

--- a/mindsdb_sql/planner/utils.py
+++ b/mindsdb_sql/planner/utils.py
@@ -75,24 +75,6 @@ def recursively_extract_column_values(op, row_dict, predictor):
         raise PlanningException(f'Only \'and\' and \'=\' operations allowed in WHERE clause, found: {op.to_tree()}')
 
 
-def recursively_check_join_identifiers_for_ambiguity(item, aliased_fields=None):
-    if item is None:
-        return
-    elif isinstance(item, Identifier):
-        if len(item.parts) == 1:
-            if aliased_fields is not None and item.parts[0] in aliased_fields:
-                # is alias
-                return
-            raise PlanningException(f'Ambigous identifier {str(item)}, provide table name for operations on a join.')
-    elif isinstance(item, Operation):
-        recursively_check_join_identifiers_for_ambiguity(item.args, aliased_fields=aliased_fields)
-    elif isinstance(item, OrderBy):
-        recursively_check_join_identifiers_for_ambiguity(item.field, aliased_fields=aliased_fields)
-    elif isinstance(item, list):
-        for arg in item:
-            recursively_check_join_identifiers_for_ambiguity(arg, aliased_fields=aliased_fields)
-
-
 def get_deepest_select(select):
     if not select.from_table or not isinstance(select.from_table, Select):
         return select

--- a/mindsdb_sql/render/sqlalchemy_render.py
+++ b/mindsdb_sql/render/sqlalchemy_render.py
@@ -412,6 +412,13 @@ class SqlalchemyRender:
             elif isinstance(from_table, ast.Identifier):
                 table = self.to_table(from_table)
                 query = query.select_from(table)
+
+            elif isinstance(from_table, ast.NativeQuery):
+                alias = None
+                if from_table.alias:
+                    alias = from_table.alias.parts[-1]
+                table = sa.text(from_table.query).columns().subquery(alias)
+                query = query.select_from(table)
             else:
                 raise NotImplementedError(f'Select from {from_table}')
 

--- a/tests/test_parser/test_base_sql/test_union.py
+++ b/tests/test_parser/test_base_sql/test_union.py
@@ -4,19 +4,18 @@ from mindsdb_sql.parser.ast import *
 from mindsdb_sql.exceptions import ParsingException
 
 
-@pytest.mark.parametrize('dialect', ['sqlite', 'mysql', 'mindsdb'])
 class TestUnion:
-    def test_single_select_error(self, dialect):
+    def test_single_select_error(self):
         sql = "SELECT col FROM tab UNION"
         with pytest.raises(ParsingException):
-            parse_sql(sql, dialect=dialect)
+            parse_sql(sql)
 
-    def test_union_base(self, dialect):
+    def test_union_base(self):
         sql = """SELECT col1 FROM tab1 
         UNION 
         SELECT col1 FROM tab2"""
 
-        ast = parse_sql(sql, dialect=dialect)
+        ast = parse_sql(sql)
         expected_ast = Union(unique=True,
                              left=Select(targets=[Identifier('col1')],
                                          from_table=Identifier(parts=['tab1']),
@@ -28,12 +27,12 @@ class TestUnion:
         assert ast.to_tree() == expected_ast.to_tree()
         assert str(ast) == str(expected_ast)
 
-    def test_union_all(self, dialect):
+    def test_union_all(self):
         sql = """SELECT col1 FROM tab1 
         UNION ALL
         SELECT col1 FROM tab2"""
 
-        ast = parse_sql(sql, dialect=dialect)
+        ast = parse_sql(sql)
         expected_ast = Union(unique=False,
                              left=Select(targets=[Identifier('col1')],
                                          from_table=Identifier(parts=['tab1']),
@@ -45,25 +44,31 @@ class TestUnion:
         assert ast.to_tree() == expected_ast.to_tree()
         assert str(ast) == str(expected_ast)
 
-    def test_union_alias(self, dialect):
+    def xtest_union_alias(self):
         sql = """SELECT * FROM (
             SELECT col1 FROM tab1
             UNION 
             SELECT col1 FROM tab2
+            UNION 
+            SELECT col1 FROM tab3
         ) AS alias"""
 
-        ast = parse_sql(sql, dialect=dialect)
+        ast = parse_sql(sql)
         expected_ast = Select(targets=[Star()],
-                              from_table=Union(unique=True,
-                                               alias=Identifier('alias'),
-                                               left=Select(
-                                                           targets=[Identifier('col1')],
-                                                           from_table=Identifier(parts=['tab1']),
-                                                           ),
-                                               right=Select(targets=[Identifier('col1')],
-                                                            from_table=Identifier(parts=['tab2']),
-                                                            ),
-                                               )
+                              from_table=Union(
+                                   unique=True,
+                                   alias=Identifier('alias'),
+                                   left=Union(
+                                       unique=True,
+                                       left=Select(
+                                                   targets=[Identifier('col1')],
+                                                   from_table=Identifier(parts=['tab1']),),
+                                       right=Select(targets=[Identifier('col1')],
+                                                    from_table=Identifier(parts=['tab2']),),
+                                   ),
+                                   right=Select(targets=[Identifier('col1')],
+                                                from_table=Identifier(parts=['tab3']),),
+                                )
                               )
         assert ast.to_tree() == expected_ast.to_tree()
         assert str(ast) == str(expected_ast)

--- a/tests/test_parser/test_mindsdb/test_timeseries.py
+++ b/tests/test_parser/test_mindsdb/test_timeseries.py
@@ -2,7 +2,6 @@ from mindsdb_sql import parse_sql
 from mindsdb_sql.parser.ast import *
 from mindsdb_sql.parser.dialects.mindsdb.latest import Latest
 from mindsdb_sql.parser.utils import JoinType
-from mindsdb_sql.planner.ts_utils import validate_ts_where_condition
 
 
 class TestTimeSeries:

--- a/tests/test_planner/test_join_predictor.py
+++ b/tests/test_planner/test_join_predictor.py
@@ -264,7 +264,7 @@ class TestPlanJoinPredictor:
             limit 1
          '''
 
-        query = parse_sql(sql, dialect='mindsdb')
+        query = parse_sql(sql)
 
         expected_plan = QueryPlan(
             default_namespace='mindsdb',
@@ -301,7 +301,7 @@ class TestPlanJoinPredictor:
                 GROUP BY 1
             '''
 
-        query = parse_sql(sql, dialect='mindsdb')
+        query = parse_sql(sql)
 
         expected_plan = QueryPlan(
             default_namespace='mindsdb',
@@ -342,7 +342,7 @@ class TestPlanJoinPredictor:
                limit 5
             '''
 
-        query = parse_sql(sql, dialect='mindsdb')
+        query = parse_sql(sql)
 
         expected_plan = QueryPlan(
             default_namespace='mindsdb',
@@ -379,7 +379,7 @@ class TestPlanJoinPredictor:
                join mindsdb.pred 
             '''
 
-        query = parse_sql(sql, dialect='mindsdb')
+        query = parse_sql(sql)
 
         expected_plan = QueryPlan(
             default_namespace='mindsdb',
@@ -414,11 +414,11 @@ class TestPredictorWithUsing:
             using a=1
         '''
 
-        query = parse_sql(sql, dialect='mindsdb')
+        query = parse_sql(sql)
         expected_plan = QueryPlan(
             steps=[
                 FetchDataframeStep(integration='int',
-                                   query=parse_sql('select * from tab1', dialect='mindsdb')),
+                                   query=parse_sql('select * from tab1')),
                 ApplyPredictorStep(namespace='mindsdb', dataframe=Result(0),
                                    predictor=Identifier('pred'), params={'a': 1}),
                 JoinStep(left=Result(0), right=Result(1),
@@ -441,7 +441,7 @@ class TestPredictorWithUsing:
                     using a=1
                 '''
 
-        query = parse_sql(sql, dialect='mindsdb')
+        query = parse_sql(sql)
         expected_plan = QueryPlan(
             steps=[
                 FetchDataframeStep(integration='int', raw_query='select * from tab1'),
@@ -468,7 +468,7 @@ class TestPredictorWithUsing:
             select * from mindsdb.pred where x=2 using a=1
         '''
 
-        query = parse_sql(sql, dialect='mindsdb')
+        query = parse_sql(sql)
         expected_plan = QueryPlan(
             steps=[
                 ApplyPredictorRowStep(namespace='mindsdb', predictor=Identifier('pred'),
@@ -491,11 +491,11 @@ class TestPredictorVersion:
             using a=1
         '''
 
-        query = parse_sql(sql, dialect='mindsdb')
+        query = parse_sql(sql)
         expected_plan = QueryPlan(
             steps=[
                 FetchDataframeStep(integration='int',
-                                   query=parse_sql('select * from tab1', dialect='mindsdb')),
+                                   query=parse_sql('select * from tab1')),
                 ApplyPredictorStep(namespace='proj', dataframe=Result(0),
                                    predictor=Identifier('pred.1'), params={'a': 1}),
                 JoinStep(left=Result(0), right=Result(1),
@@ -519,7 +519,7 @@ class TestPredictorVersion:
             join pred.1
             using a=1
         '''
-        query = parse_sql(sql, dialect='mindsdb')
+        query = parse_sql(sql)
 
         plan = plan_query(query, integrations=['int'], predictor_namespace='mindsdb',
                           default_namespace='proj', predictor_metadata=[{'name': 'pred', 'integration_name': 'proj'}])
@@ -541,11 +541,11 @@ class TestPredictorVersion:
         """)
         subquery.from_table = None
 
-        query = parse_sql(sql, dialect='mindsdb')
+        query = parse_sql(sql)
         expected_plan = QueryPlan(
             steps=[
                 FetchDataframeStep(integration='int',
-                                   query=parse_sql('select * from tab1 as a where x=1 and y=3', dialect='mindsdb')),
+                                   query=parse_sql('select * from tab1 as a where x=1 and y=3')),
                 ApplyPredictorStep(
                     namespace='proj', dataframe=Result(0),
                     predictor=Identifier('pred.1', alias=Identifier('p')),
@@ -570,7 +570,7 @@ class TestPredictorVersion:
             select * from proj.pred.1 where x=2 using a=1
         '''
 
-        query = parse_sql(sql, dialect='mindsdb')
+        query = parse_sql(sql)
         expected_plan = QueryPlan(
             steps=[
                 ApplyPredictorRowStep(namespace='proj', predictor=Identifier('pred.1'),
@@ -589,7 +589,7 @@ class TestPredictorVersion:
         sql = '''
              select * from pred.1 where x=2 using a=1
         '''
-        query = parse_sql(sql, dialect='mindsdb')
+        query = parse_sql(sql)
 
         plan = plan_query(query, integrations=['int'], predictor_namespace='mindsdb',
                           default_namespace='proj', predictor_metadata=[{'name': 'pred', 'integration_name': 'proj'}])
@@ -605,7 +605,7 @@ class TestPredictorParams:
             where m.a=1 and t.b=2
         '''
 
-        query = parse_sql(sql, dialect='mindsdb')
+        query = parse_sql(sql)
 
         subquery = parse_sql("""
             select * from x
@@ -616,7 +616,7 @@ class TestPredictorParams:
         expected_plan = QueryPlan(
             steps=[
                 FetchDataframeStep(integration='int',
-                                   query=parse_sql('select * from tab1 as t where b=2', dialect='mindsdb')),
+                                   query=parse_sql('select * from tab1 as t where b=2')),
                 ApplyPredictorStep(namespace='mindsdb', dataframe=Result(0),
                                    predictor=Identifier('pred', alias=Identifier('m')), row_dict={'a': 1}),
                 JoinStep(left=Result(0), right=Result(1),
@@ -645,13 +645,13 @@ class TestPredictorParams:
         """)
         subquery.from_table = None
 
-        query = parse_sql(sql, dialect='mindsdb')
+        query = parse_sql(sql)
         expected_plan = QueryPlan(
             steps=[
                 FetchDataframeStep(integration='int',
-                                   query=parse_sql('select * from tab1 as t', dialect='mindsdb')),
+                                   query=parse_sql('select * from tab1 as t')),
                 FetchDataframeStep(integration='int',
-                                   query=parse_sql('select * from tab2 as t2', dialect='mindsdb')),
+                                   query=parse_sql('select * from tab2 as t2')),
                 JoinStep(left=Result(0), right=Result(1),
                          query=Join(left=Identifier('tab1'),
                                     right=Identifier('tab2'),
@@ -669,40 +669,61 @@ class TestPredictorParams:
 
         assert plan.steps == expected_plan.steps
 
-    def test_model_param_subselect(self):
+    def test_complex_subselect(self):
+
         sql = '''
-                    select * from int.tab1 t
-                    join int.tab2 t2
-                    join mindsdb.pred m
-                    where m.a = (select a from int.tab3 where x=1)
-                '''
+                select t2.x, m.id, (select a from int.tab0 where x=0) from int.tab1 t1
+                join int.tab2 t2 on t1.x = t2.x 
+                join mindsdb.pred m
+                where m.a=(select a from int.tab3 where x=3) 
+                  and t2.x=(select a from int.tab4 where x=4)
+                  and t1.b=1 and t2.b=2 and t1.a = t2.a
+        '''
+
+        q_table2 = parse_sql('select * from tab2 as t2 where x=0 and b=2 ')
+        q_table2.where.args[0].args[1] = Parameter(Result(2))
 
         subquery = parse_sql("""
-            select * from x
-            where 0=0
+            select t2.x, m.id, x 
+            from x
+            where 0=0 
+                  and t2.x=x
+                  and t1.b=1 and t2.b=2 and t1.a = t2.a
         """)
         subquery.from_table = None
+        subquery.targets[2] = Parameter(Result(0))
+        subquery.where.args[0].args[0].args[0].args[1].args[1] = Parameter(Result(2))
 
-        query = parse_sql(sql, dialect='mindsdb')
+
+        query = parse_sql(sql)
         expected_plan = QueryPlan(
             steps=[
+                # nested queries
                 FetchDataframeStep(integration='int',
-                                   query=parse_sql('select tab3.a as a from tab3 where tab3.x=1', dialect='mindsdb')),
+                                   query=parse_sql('select tab0.a as a from tab0 where tab0.x=0')),
                 FetchDataframeStep(integration='int',
-                                   query=parse_sql('select * from tab1 as t', dialect='mindsdb')),
+                                   query=parse_sql('select tab3.a as a from tab3 where tab3.x=3')),
                 FetchDataframeStep(integration='int',
-                                   query=parse_sql('select * from tab2 as t2', dialect='mindsdb')),
-                JoinStep(left=Result(1), right=Result(2),
-                         query=Join(left=Identifier('tab1'),
-                                    right=Identifier('tab2'),
-                                    join_type=JoinType.JOIN)),
-                ApplyPredictorStep(namespace='mindsdb', dataframe=Result(3),
-                                   predictor=Identifier('pred', alias=Identifier('m')), row_dict={'a': Result(step_num=0)}),
+                                   query=parse_sql('select tab4.a as a from tab4 where tab4.x=4')),
+                # tables
+                FetchDataframeStep(integration='int',
+                                   query=parse_sql('select * from tab1 as t1 where b=1')),
+                FetchDataframeStep(integration='int', query=q_table2),
                 JoinStep(left=Result(3), right=Result(4),
                          query=Join(left=Identifier('tab1'),
                                     right=Identifier('tab2'),
+                                    join_type=JoinType.JOIN,
+                                    condition=BinaryOperation(op='=', args=[Identifier('t1.x'), Identifier('t2.x')])
+                        )
+                ),
+                # model
+                ApplyPredictorStep(namespace='mindsdb', dataframe=Result(5),
+                                   predictor=Identifier('pred', alias=Identifier('m')), row_dict={'a': Result(1)}),
+                JoinStep(left=Result(5), right=Result(6),
+                         query=Join(left=Identifier('tab1'),
+                                    right=Identifier('tab2'),
                                     join_type=JoinType.JOIN)),
-                QueryStep(subquery, from_table=Result(5)),
+                QueryStep(subquery, from_table=Result(7)),
             ],
         )
         plan = plan_query(query, integrations=['int'], predictor_namespace='mindsdb', predictor_metadata={'pred': {}})
@@ -723,11 +744,11 @@ class TestPredictorParams:
         """)
         subquery.from_table = None
 
-        query = parse_sql(sql, dialect='mindsdb')
+        query = parse_sql(sql)
         expected_plan = QueryPlan(
             steps=[
                 FetchDataframeStep(integration='int',
-                                   query=parse_sql('select * from tab1 as t', dialect='mindsdb')),
+                                   query=parse_sql('select * from tab1 as t')),
                 ApplyPredictorStep(namespace='mindsdb', dataframe=Result(0),
                                    predictor=Identifier('pred', alias=Identifier('m')), row_dict={'a': 2}),
                 JoinStep(left=Result(0), right=Result(1),

--- a/tests/test_planner/test_prepared_statement.py
+++ b/tests/test_planner/test_prepared_statement.py
@@ -48,6 +48,7 @@ class FakeExecutor:
                     {'name': 'predicted', 'type': 'float'},
                     {'name': 'target', 'type': 'float'},
                     {'name': 'sqft', 'type': 'float'},
+                    {'name': 'x', 'type': 'int'},
                 ]
                 return self.list_cols_return(step.table, cols)
             return None

--- a/tests/test_planner/test_ts_predictor.py
+++ b/tests/test_planner/test_ts_predictor.py
@@ -1385,3 +1385,73 @@ class TestJoinTimeseriesPredictor:
             # print(plan.steps[i])
             # print(expected_plan.steps[i])
             assert plan.steps[i] == expected_plan.steps[i]
+
+
+    def test_join_native_query(self):
+        query = parse_sql('''
+            SELECT *
+            FROM int1 (select * from tab) as t
+            JOIN pred as m
+            WHERE t.date > LATEST
+        ''')
+
+        group_by_column = 'type'
+
+        plan = plan_query(
+            query,
+            integrations=['int1'],
+            default_namespace='proj',
+            predictor_metadata=[{
+                'name': 'pred',
+                'integration_name': 'proj',
+                'timeseries': True,
+                'window': 10, 'horizon': 10, 'order_by_column': 'date', 'group_by_columns': [group_by_column]
+            }]
+        )
+
+        expected_plan = QueryPlan(steps=[
+            FetchDataframeStep(
+                integration='int1',
+                query=Select(
+                    targets=[Identifier('t.type', alias=Identifier('type'))],
+                    from_table=NativeQuery(query='select * from tab', integration=Identifier('int1'), alias=Identifier('t')),
+                    distinct=True
+                )
+            ),
+            MapReduceStep(
+                values=Result(0),
+                reduce='union',
+                step=FetchDataframeStep(integration='int1',
+                    query=Select(
+                        targets=[Star()],
+                        from_table=NativeQuery(query='select * from tab', integration=Identifier('int1'), alias=Identifier('t')),
+                        distinct=False,
+                        limit=Constant(10),
+                        order_by=[OrderBy(field=Identifier('t.date'), direction='DESC')],
+                        where=BinaryOperation('and', args=[
+                            BinaryOperation('is not', args=[Identifier('t.date'), NullConstant()]),
+                            BinaryOperation('=', args=[Identifier('t.type'), Constant('$var[type]')]),
+                        ])
+                    )
+                ),
+            ),
+            ApplyTimeseriesPredictorStep(
+                namespace='proj',
+                predictor=Identifier('pred', alias=Identifier('m')),
+                dataframe=Result(1),
+                output_time_filter=BinaryOperation('>', args=[Identifier('t.date'), Latest()]),
+            ),
+            JoinStep(
+                left=Result(1),
+                right=Result(2),
+                query=Join(
+                    left=Identifier('result_1'),
+                    right=Identifier('result_2'),
+                    join_type=JoinType.JOIN
+                )
+            )
+        ])
+
+        assert len(plan.steps) == len(expected_plan.steps)
+        for i in range(len(plan.steps)):
+            assert plan.steps[i] == expected_plan.steps[i]

--- a/tests/test_render/test_sqlalchemyrender.py
+++ b/tests/test_render/test_sqlalchemyrender.py
@@ -26,7 +26,7 @@ modules = (
 )
 
 
-def parse_sql2(sql, dialect='sqlite'):
+def parse_sql2(sql, dialect='mindsdb'):
     # convert to ast
     query = parse_sql(sql, dialect)
 


### PR DESCRIPTION
Changes:
- Planner for api database: additional processing query fixes #320
  - Call query only with 'where' and 'limit' in API database
  - Perform other operations in executor 
- Union 3 and more tables  fixes #333
- Joins
  - All steps after join combined to Query step
  - Logic of joins moved to subclasses: for regular and TS join
  - Unified join logic for 'model join table': it is moved to main join class 
  - Support join TS model with #323
- render native query in sqlalchemy render
