### PR TITLE
Interval support

### DIFF
--- a/mindsdb_sql/parser/ast/select/__init__.py
+++ b/mindsdb_sql/parser/ast/select/__init__.py
@@ -7,7 +7,8 @@ from .identifier import Identifier
 from .join import Join
 from .type_cast import TypeCast
 from .tuple import Tuple
-from .operation import Operation, BinaryOperation, UnaryOperation, BetweenOperation, Function, WindowFunction, Object
+from .operation import (Operation, BinaryOperation, UnaryOperation, BetweenOperation,
+                        Function, WindowFunction, Object, Interval)
 from .order_by import OrderBy
 from .parameter import Parameter
 from .case import Case

--- a/mindsdb_sql/parser/ast/select/operation.py
+++ b/mindsdb_sql/parser/ast/select/operation.py
@@ -167,3 +167,19 @@ class Object(ASTNode):
 
     def __repr__(self):
         return self.to_tree()
+
+
+class Interval(Operation):
+
+    def __init__(self, info):
+        super().__init__(op='interval', args=[info, ])
+
+    def get_string(self, *args, **kwargs):
+        return f'INTERVAL {repr(self.args[0])}'
+
+    def to_tree(self, *args, level=0, **kwargs):
+        return self.get_string( *args, **kwargs)
+
+    def assert_arguments(self):
+        if len(self.args) != 1:
+            raise ParsingException(f'Expected one argument for operation "{self.op}"')

--- a/mindsdb_sql/parser/dialects/mindsdb/lexer.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/lexer.py
@@ -72,7 +72,7 @@ class MindsDBLexer(Lexer):
         EQUALS, NEQUALS, GREATER, GEQ, LESS, LEQ,
         AND, OR, NOT, IS, IS_NOT,
         IN, LIKE, NOT_LIKE, CONCAT, BETWEEN, WINDOW, OVER, PARTITION_BY,
-        JSON_GET, JSON_GET_STR,
+        JSON_GET, JSON_GET_STR, INTERVAL,
 
         # Data types
         CAST, ID, INTEGER, FLOAT, QUOTE_STRING, DQUOTE_STRING, NULL, TRUE, FALSE,
@@ -287,6 +287,7 @@ class MindsDBLexer(Lexer):
     CAST = r'\bCAST\b'
     CONCAT = r'\|\|'
     BETWEEN = r'\bBETWEEN\b'
+    INTERVAL = r'\bINTERVAL\b'
     WINDOW = r'\bWINDOW\b'
     OVER = r'\bOVER\b'
     PARTITION_BY = r'\bPARTITION BY\b'

--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -1329,6 +1329,10 @@ class MindsDBParser(Parser):
             args = []
         return Function(op=p[0], args=args)
 
+    @_('INTERVAL string')
+    def expr(self, p):
+        return Interval(p.string)
+
     # arguments are optional in functions, so that things like `select database()` are possible
     @_('expr BETWEEN expr AND expr')
     def expr(self, p):
@@ -1613,6 +1617,7 @@ class MindsDBParser(Parser):
        'INDEX',
        'INTEGRATION',
        'INTEGRATIONS',
+       'INTERVAL',
        'ISOLATION',
        'KEYS',
        'LATEST',

--- a/tests/test_parser/test_base_sql/test_misc_sql_queries.py
+++ b/tests/test_parser/test_base_sql/test_misc_sql_queries.py
@@ -221,3 +221,32 @@ class TestMindsdb:
         assert ast.to_tree() == expected_ast.to_tree()
         assert str(ast) == str(expected_ast)
 
+    def test_interval(self):
+        sql = """
+           select interval '1 day'+1 from aaa
+           where 'a' > interval "3 day 1 min"
+        """
+
+        expected_ast = Select(
+            targets=[
+                BinaryOperation(op='+', args=[
+                    Interval('1 day'),
+                    Constant(1)
+                ])
+            ],
+            from_table=Identifier('aaa'),
+            where=BinaryOperation(
+                op='>',
+                args=[
+                    Constant('a'),
+                    Interval('3 day 1 min'),
+                ]
+            )
+        )
+
+        ast = parse_sql(sql)
+
+        assert str(ast).lower() == str(expected_ast).lower()
+        assert ast.to_tree() == expected_ast.to_tree()
+
+

--- a/tests/test_render/test_sqlalchemyrender.py
+++ b/tests/test_render/test_sqlalchemyrender.py
@@ -14,6 +14,7 @@ from tests.test_parser.test_base_sql import (
     test_select_common_table_expression,
     test_select_structure,
     test_union,
+    test_misc_sql_queries,
 )
 
 modules = (
@@ -23,6 +24,7 @@ modules = (
     test_select_common_table_expression,
     test_select_structure,
     test_union,
+    test_misc_sql_queries
 )
 
 


### PR DESCRIPTION
Support interval function for posgres
- parsing
- sqlalchemy render

```sql
select interval '1 day' from my_pg.table;
```

Fixes: https://github.com/mindsdb/mindsdb/issues/8591