### PR TITLE
No aliases to FetchDataframeStep

### DIFF
--- a/mindsdb_sql/planner/plan_join_ts.py
+++ b/mindsdb_sql/planner/plan_join_ts.py
@@ -195,13 +195,16 @@ class PlanJoinTSPredictorQuery:
         allowed_columns = [predictor_time_column_name.lower()]
         if len(predictor_group_by_names) > 0:
             allowed_columns += [i.lower() for i in predictor_group_by_names]
-        validate_ts_where_condition(query.where, allowed_columns=allowed_columns)
 
-        time_filter = find_time_filter(query.where, time_column_name=predictor_time_column_name)
+        no_time_filter_query = copy.deepcopy(query)
+
+        preparation_where = no_time_filter_query.where
+
+        validate_ts_where_condition(preparation_where, allowed_columns=allowed_columns)
+
+        time_filter = find_time_filter(preparation_where, time_column_name=predictor_time_column_name)
 
         order_by = [OrderBy(Identifier(parts=[predictor_time_column_name]), direction='DESC')]
-
-        preparation_where = copy.deepcopy(query.where)
 
         query_modifiers = query.modifiers
 
@@ -342,7 +345,6 @@ class PlanJoinTSPredictorQuery:
                     steps=[self.planner.get_integration_select_step(s) for s in integration_selects], reduce='union')
 
             # get groping values
-            no_time_filter_query = copy.deepcopy(query)
             no_time_filter_query.where = find_and_remove_time_filter(no_time_filter_query.where, time_filter)
             select_partitions_step = self.plan_fetch_timeseries_partitions(no_time_filter_query, table, predictor_group_by_names)
 

--- a/mindsdb_sql/planner/query_planner.py
+++ b/mindsdb_sql/planner/query_planner.py
@@ -151,8 +151,6 @@ class QueryPlanner:
                     if node.parts[:len(prefix)] != prefix:
                         raise PlanningException(f'Tried to query column {node.to_string()} from table'
                                                 f' {table.to_string()}, but a different table name has been specified.')
-                else:
-                    node.parts = prefix + node.parts
 
                 # keep column name for target
                 if is_target:

--- a/mindsdb_sql/planner/ts_utils.py
+++ b/mindsdb_sql/planner/ts_utils.py
@@ -66,6 +66,8 @@ def validate_ts_where_condition(op, allowed_columns, allow_and=True):
             if arg.parts[-1].lower() not in allowed_columns:
                 raise PlanningException(
                     f'For time series predictor only the following columns are allowed in WHERE: {str(allowed_columns)}, found instead: {str(arg)}.')
+            # remove alias
+            arg.parts = [arg.parts[-1]]
 
     if isinstance(op.args[0], Operation):
         validate_ts_where_condition(op.args[0], allowed_columns, allow_and=True)

--- a/mindsdb_sql/render/sqlalchemy_render.py
+++ b/mindsdb_sql/render/sqlalchemy_render.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import aliased
 from sqlalchemy.dialects import mysql, postgresql, sqlite, mssql, oracle
 from sqlalchemy.schema import CreateTable, DropTable
 from sqlalchemy.sql import ColumnElement
+from sqlalchemy.sql import functions as sa_fnc
 
 from mindsdb_sql.parser import ast
 
@@ -114,7 +115,20 @@ class SqlalchemyRender:
                     alias = str(t.value)
             col = col.label(alias)
         elif isinstance(t, ast.Identifier):
-            col = self.to_column(t.parts)
+            # sql functions
+            col = None
+            if len(t.parts) == 1:
+                name = t.parts[0].upper()
+                if name == 'CURRENT_DATE':
+                    col = sa_fnc.current_date()
+                elif name == 'CURRENT_TIME':
+                    col = sa_fnc.current_time()
+                elif name == 'CURRENT_TIMESTAMP':
+                    col = sa_fnc.current_timestamp()
+                elif name == 'CURRENT_USER':
+                    col = sa_fnc.current_user()
+            if col is None:
+                col = self.to_column(t.parts)
             if t.alias:
                 col = col.label(self.get_alias(t.alias))
         elif isinstance(t, ast.Select):

--- a/tests/test_planner/test_integration_select.py
+++ b/tests/test_planner/test_integration_select.py
@@ -21,7 +21,7 @@ class TestPlanIntegrationSelect:
         expected_plan = QueryPlan(integrations=['int'],
                                   steps=[
                                       FetchDataframeStep(integration='int',
-                                                         query=Select(targets=[Identifier('tab.column1', alias=Identifier('column1')),
+                                                         query=Select(targets=[Identifier('column1', alias=Identifier('column1')),
                                                                                Constant(1),
                                                                                NullConstant(),
                                                                                Function('database', args=[]),
@@ -29,10 +29,10 @@ class TestPlanIntegrationSelect:
                                                                       from_table=Identifier('tab'),
                                                                       where=BinaryOperation('and', args=[
                                                                               BinaryOperation('=',
-                                                                                              args=[Identifier('tab.column1'),
-                                                                                                    Identifier('tab.column2')]),
+                                                                                              args=[Identifier('column1'),
+                                                                                                    Identifier('column2')]),
                                                                               BinaryOperation('>',
-                                                                                              args=[Identifier('tab.column3'),
+                                                                                              args=[Identifier('column3'),
                                                                                                     Constant(0)]),
                                                                           ])
                                                                       ),
@@ -47,7 +47,7 @@ class TestPlanIntegrationSelect:
             assert plan.steps[i] == expected_plan.steps[i]
 
     def test_integration_name_is_case_insensitive(self):
-        query = Select(targets=[Identifier('column1')],
+        query = Select(targets=[Identifier('tab.column1')],
                        from_table=Identifier('int.tab'),
                        where=BinaryOperation('and', args=[
                            BinaryOperation('=', args=[Identifier('column1'), Identifier('column2')]),
@@ -60,10 +60,10 @@ class TestPlanIntegrationSelect:
                                                                       from_table=Identifier('tab'),
                                                                       where=BinaryOperation('and', args=[
                                                                               BinaryOperation('=',
-                                                                                              args=[Identifier('tab.column1'),
-                                                                                                    Identifier('tab.column2')]),
+                                                                                              args=[Identifier('column1'),
+                                                                                                    Identifier('column2')]),
                                                                               BinaryOperation('>',
-                                                                                              args=[Identifier('tab.column3'),
+                                                                                              args=[Identifier('column3'),
                                                                                                     Constant(0)]),
                                                                           ])
                                                                       )),
@@ -85,11 +85,11 @@ class TestPlanIntegrationSelect:
                                   steps=[
                                       FetchDataframeStep(integration='int',
                                                          query=Select(
-                                                             targets=[Identifier('tab.column1', alias=Identifier('column1'))],
+                                                             targets=[Identifier('column1', alias=Identifier('column1'))],
                                                              from_table=Identifier('tab'),
-                                                             where=BinaryOperation('=', args=[Identifier('tab.column1'),
+                                                             where=BinaryOperation('=', args=[Identifier('column1'),
                                                                                               Identifier(
-                                                                                                  'tab.column2')]),
+                                                                                                  'column2')]),
                                                              limit=Constant(10),
                                                              offset=Constant(15),
                                                              ),
@@ -107,17 +107,17 @@ class TestPlanIntegrationSelect:
                        where=BinaryOperation('=', args=[Identifier('column1'), Identifier('column2')]),
                        limit=Constant(10),
                        offset=Constant(15),
-                       order_by=[OrderBy(field=Identifier('column1'))],
+                       order_by=[OrderBy(field=Identifier('tab.column1'))],
                        )
         expected_plan = QueryPlan(integrations=['int'],
                                   steps=[
                                       FetchDataframeStep(integration='int',
                                                          query=Select(
-                                                             targets=[Identifier('tab.column1', alias=Identifier('column1'))],
+                                                             targets=[Identifier('column1', alias=Identifier('column1'))],
                                                              from_table=Identifier('tab'),
-                                                             where=BinaryOperation('=', args=[Identifier('tab.column1'),
+                                                             where=BinaryOperation('=', args=[Identifier('column1'),
                                                                                               Identifier(
-                                                                                                  'tab.column2')]),
+                                                                                                  'column2')]),
                                                              limit=Constant(10),
                                                              offset=Constant(15),
                                                              order_by=[OrderBy(field=Identifier('tab.column1'))],
@@ -165,7 +165,7 @@ class TestPlanIntegrationSelect:
         
 
     def test_integration_select_table_alias(self):
-        query = Select(targets=[Identifier('col1')],
+        query = Select(targets=[Identifier('alias.col1')],
                        from_table=Identifier('int.tab', alias=Identifier('alias')))
 
         expected_plan = QueryPlan(integrations=['int'],
@@ -191,7 +191,7 @@ class TestPlanIntegrationSelect:
                                   steps=[
                                       FetchDataframeStep(integration='int',
                                                          query=Select(
-                                                             targets=[Identifier(parts=['tab', 'col1'], alias=Identifier('column_alias'))],
+                                                             targets=[Identifier(parts=['col1'], alias=Identifier('column_alias'))],
                                                              from_table=Identifier(parts=['tab'])),
                                                          ),
                                   ])
@@ -233,16 +233,16 @@ class TestPlanIntegrationSelect:
                                   steps=[
                                       FetchDataframeStep(integration='int',
                                                          query=Select(targets=[
-                                                             Identifier('tab.column1', alias=Identifier('column1')),
-                                                             Identifier('tab.column2', alias=Identifier('column2')),
+                                                             Identifier('column1', alias=Identifier('column1')),
+                                                             Identifier('column2', alias=Identifier('column2')),
                                                              Function(op="sum",
-                                                                      args=[Identifier(parts=['tab', 'column3'])],
+                                                                      args=[Identifier(parts=['column3'])],
                                                                       alias=Identifier('total')),
 
                                                          ],
                                                              from_table=Identifier('tab'),
-                                                             group_by=[Identifier('tab.column1'), Identifier('tab.column2')],
-                                                             having=BinaryOperation('=', args=[Identifier('tab.column1'),
+                                                             group_by=[Identifier('column1'), Identifier('column2')],
+                                                             having=BinaryOperation('=', args=[Identifier('column1'),
                                                                                                Constant(0)])
                                                          )),
                                   ])
@@ -267,8 +267,8 @@ class TestPlanIntegrationSelect:
         expected_plan = QueryPlan(integrations=['int'],
                                   steps=[
                                       FetchDataframeStep(integration='int',
-                                                         query=Select(targets=[Identifier('tab.column1', alias=Identifier('column1')),
-                                                                               Select(targets=[Identifier('tab.column2', alias=Identifier('column2'))],
+                                                         query=Select(targets=[Identifier('column1', alias=Identifier('column1')),
+                                                                               Select(targets=[Identifier('column2', alias=Identifier('column2'))],
                                                                                       from_table=Identifier('tab'),
                                                                                       limit=Constant(1),
                                                                                       alias=Identifier('subquery'))
@@ -293,7 +293,7 @@ class TestPlanIntegrationSelect:
                                                          query=Select(
                                                              targets=[Identifier('column1')],
                                                              from_table=Select(
-                                                                 targets=[Identifier('tab.column1', alias=Identifier('column1'))],
+                                                                 targets=[Identifier('column1', alias=Identifier('column1'))],
                                                                  from_table=Identifier('tab'),
                                                                  alias=Identifier('subquery')),
                                                              )),
@@ -322,9 +322,9 @@ class TestPlanIntegrationSelect:
                                                                       from_table=Identifier('tab1'),
                                                                       where=BinaryOperation(op='in',
                                                                                             args=[
-                                                                                                Identifier('tab1.column1'),
+                                                                                                Identifier('column1'),
                                                                                                 Select(targets=[
-                                                                                                    Identifier('tab2.column2', alias=Identifier('column2'))],
+                                                                                                    Identifier('column2', alias=Identifier('column2'))],
                                                                                                        from_table=Identifier('tab2'),
                                                                                                        parentheses=True)]
                                                                                             ))),
@@ -346,17 +346,17 @@ class TestPlanIntegrationSelect:
                                   default_namespace='int',
                                   steps=[
                                       FetchDataframeStep(integration='int',
-                                                         query=Select(targets=[Identifier('tab.column1', alias=Identifier('column1')),
+                                                         query=Select(targets=[Identifier('column1', alias=Identifier('column1')),
                                                                                Constant(1),
                                                                                Function('database', args=[]),
                                                                                ],
                                                                       from_table=Identifier('tab'),
                                                                       where=BinaryOperation('and', args=[
                                                                               BinaryOperation('=',
-                                                                                              args=[Identifier('tab.column1'),
-                                                                                                    Identifier('tab.column2')]),
+                                                                                              args=[Identifier('column1'),
+                                                                                                    Identifier('column2')]),
                                                                               BinaryOperation('>',
-                                                                                              args=[Identifier('tab.column3'),
+                                                                                              args=[Identifier('column3'),
                                                                                                     Constant(0)]),
                                                                           ])
                                                                       ),
@@ -382,7 +382,7 @@ class TestPlanIntegrationSelect:
                                                          query=Select(
                                                              targets=[Identifier('column1')],
                                                              from_table=Select(
-                                                                 targets=[Identifier('tab.column1', alias=Identifier('column1'))],
+                                                                 targets=[Identifier('column1', alias=Identifier('column1'))],
                                                                  from_table=Identifier('tab'),
                                                                  alias=Identifier('subquery')),
                                                              )),
@@ -405,7 +405,7 @@ class TestPlanIntegrationSelect:
                                              targets=[Star()],
                                              from_table=Identifier('yyy.zzz'),
                                              where=BinaryOperation(op='>', args=[
-                                                 Identifier('yyy.zzz.x'),
+                                                 Identifier('x'),
                                                  Constant(1)
                                              ])
                                           )
@@ -484,7 +484,7 @@ class TestPlanIntegrationSelect:
             steps=[
                 FetchDataframeStep(
                     integration='int1',
-                    query=parse_sql('select tab1.id as id from tab1'),
+                    query=parse_sql('select id as id from tab1'),
                 ),
                 FetchDataframeStep(
                     integration='int2',
@@ -494,7 +494,7 @@ class TestPlanIntegrationSelect:
                         where=BinaryOperation(
                             op='in',
                             args=[
-                                Identifier(parts=['tab1', 'x1']),
+                                Identifier(parts=['x1']),
                                 Parameter(Result(0))
                             ]
                         )
@@ -523,7 +523,7 @@ class TestPlanIntegrationSelect:
             steps=[
                 FetchDataframeStep(
                     integration='int1',
-                    query=parse_sql('select tab1.`id` AS `id` from tab1'),
+                    query=parse_sql('select `id` AS `id` from tab1'),
                 ),
                 SubSelectStep(
                     dataframe=Result(0),
@@ -533,12 +533,12 @@ class TestPlanIntegrationSelect:
                 FetchDataframeStep(
                     integration='int1',
                     query=Select(
-                        targets=[Identifier('tab2.x', alias=Identifier('x'))],
+                        targets=[Identifier('x', alias=Identifier('x'))],
                         from_table=Identifier('tab2'),
                         where=BinaryOperation(
                             op='in',
                             args=[
-                                Identifier(parts=['tab2', 'x1']),
+                                Identifier(parts=['x1']),
                                 Parameter(Result(1))
                             ]
                         ),
@@ -572,7 +572,7 @@ class TestPlanIntegrationSelect:
             steps=[
                 FetchDataframeStep(
                     integration='int1',
-                    query=parse_sql('select * from tab1 where tab1.x1 in (select tab1.id as id from tab1)'),
+                    query=parse_sql('select * from tab1 where x1 in (select id as id from tab1)'),
                 ),
             ],
         )
@@ -596,7 +596,7 @@ class TestPlanIntegrationSelect:
             steps=[
                 FetchDataframeStep(
                     integration='int1',
-                    query=parse_sql('select tab1.`id` AS `id` from tab1'),
+                    query=parse_sql('select `id` AS `id` from tab1'),
                 ),
                 SubSelectStep(
                     dataframe=Result(0),
@@ -630,7 +630,7 @@ class TestPlanIntegrationSelect:
             where x1 in (select id from int1.tab1)
         ''', dialect='mindsdb')
 
-        subselect = parse_sql('select tab1.id as id from tab1')
+        subselect = parse_sql('select id as id from tab1')
         subselect.parentheses = True
         expected_plan = QueryPlan(
             predictor_namespace='mindsdb',
@@ -667,7 +667,7 @@ class TestPlanIntegrationSelect:
             steps=[
                 FetchDataframeStep(
                     integration='int2',
-                    query=parse_sql('select tab1.id as id from tab1'),
+                    query=parse_sql('select id as id from tab1'),
                 ),
                 DeleteStep(
                     table=Identifier('int1.tab1'),

--- a/tests/test_planner/test_join_predictor.py
+++ b/tests/test_planner/test_join_predictor.py
@@ -348,7 +348,7 @@ class TestPlanJoinPredictor:
             default_namespace='mindsdb',
             steps=[
                 FetchDataframeStep(integration='int',
-                                   query=parse_sql('select covid.col as col from covid limit 10')),
+                                   query=parse_sql('select col as col from covid limit 10')),
                 SubSelectStep(query=Select(targets=[Star()]), dataframe=Result(0), table_name='t'),
                 ApplyPredictorStep(namespace='mindsdb', dataframe=Result(1), predictor=Identifier('pred')),
                 JoinStep(left=Result(1), right=Result(2),
@@ -700,11 +700,11 @@ class TestPredictorParams:
             steps=[
                 # nested queries
                 FetchDataframeStep(integration='int',
-                                   query=parse_sql('select tab0.a as a from tab0 where tab0.x=0')),
+                                   query=parse_sql('select a as a from tab0 where x=0')),
                 FetchDataframeStep(integration='int',
-                                   query=parse_sql('select tab3.a as a from tab3 where tab3.x=3')),
+                                   query=parse_sql('select a as a from tab3 where x=3')),
                 FetchDataframeStep(integration='int',
-                                   query=parse_sql('select tab4.a as a from tab4 where tab4.x=4')),
+                                   query=parse_sql('select a as a from tab4 where x=4')),
                 # tables
                 FetchDataframeStep(integration='int',
                                    query=parse_sql('select * from tab1 as t1 where b=1')),

--- a/tests/test_planner/test_mindsdb_predictors_select.py
+++ b/tests/test_planner/test_mindsdb_predictors_select.py
@@ -21,7 +21,7 @@ class TestPlanPredictorsSelect:
         expected_plan = QueryPlan(integrations=['mindsdb'],
                                   steps=[
                                       FetchDataframeStep(integration='mindsdb',
-                                                         query=Select(targets=[Identifier('predictors.column1', alias=Identifier('column1')),
+                                                         query=Select(targets=[Identifier('column1', alias=Identifier('column1')),
                                                                                Constant(1),
                                                                                NullConstant(),
                                                                                Function('database', args=[]),
@@ -29,10 +29,10 @@ class TestPlanPredictorsSelect:
                                                                       from_table=Identifier('predictors'),
                                                                       where=BinaryOperation('and', args=[
                                                                               BinaryOperation('=',
-                                                                                              args=[Identifier('predictors.column1'),
-                                                                                                    Identifier('predictors.column2')]),
+                                                                                              args=[Identifier('column1'),
+                                                                                                    Identifier('column2')]),
                                                                               BinaryOperation('>',
-                                                                                              args=[Identifier('predictors.column3'),
+                                                                                              args=[Identifier('column3'),
                                                                                                     Constant(0)]),
                                                                           ])
                                                                       ),

--- a/tests/test_planner/test_plan_union.py
+++ b/tests/test_planner/test_plan_union.py
@@ -30,15 +30,15 @@ class TestPlanUnion:
             steps=[
                 # Query 1
                 FetchDataframeStep(integration='int',
-                                   query=Select(targets=[Identifier('tab.column1', alias=Identifier('column1')),
+                                   query=Select(targets=[Identifier('column1', alias=Identifier('column1')),
                                                          Constant(None, alias=Identifier('predicted'))],
                                                 from_table=Identifier('tab'),
                                                 where=BinaryOperation('and', args=[
                                                     BinaryOperation('=',
-                                                                    args=[Identifier('tab.column1'),
-                                                                          Identifier('tab.column2')]),
+                                                                    args=[Identifier('column1'),
+                                                                          Identifier('column2')]),
                                                     BinaryOperation('>',
-                                                                    args=[Identifier('tab.column3'),
+                                                                    args=[Identifier('column3'),
                                                                           Constant(0)]),
                                                 ])
                                                 )),

--- a/tests/test_planner/test_prepared_statement.py
+++ b/tests/test_planner/test_prepared_statement.py
@@ -43,6 +43,7 @@ class FakeExecutor:
                     {'name': 'column1', 'type': 'str'},
                     {'name': 'column2', 'type': 'str'},
                     {'name': 'column3', 'type': 'str'},
+                    {'name': 'col1', 'type': 'str'},
                     {'name': 'asset', 'type': 'float'},
                     {'name': 'time', 'type': 'datetime'},
                     {'name': 'predicted', 'type': 'float'},

--- a/tests/test_planner/test_select_from_predictor.py
+++ b/tests/test_planner/test_select_from_predictor.py
@@ -247,7 +247,7 @@ class TestPlanSelectFromPredictor:
             steps=[
                 FetchDataframeStep(
                     integration='int1',
-                    query=parse_sql('select t1.id as id from t1'),
+                    query=parse_sql('select id as id from t1'),
                 ),
                 ApplyPredictorRowStep(
                     namespace='mindsdb',
@@ -276,7 +276,7 @@ class TestPlanSelectFromPredictor:
             steps=[
                 FetchDataframeStep(
                     integration='int1',
-                    query=parse_sql('select tab1.id as id from tab1'),
+                    query=parse_sql('select id as id from tab1'),
                 ),
                 FetchDataframeStep(
                     integration='mindsdb',
@@ -286,7 +286,7 @@ class TestPlanSelectFromPredictor:
                         where=BinaryOperation(
                             op='in',
                             args=[
-                                Identifier(parts=['v1', 'x1']),
+                                Identifier(parts=['x1']),
                                 Parameter(Result(0))
                             ]
                         )
@@ -308,7 +308,7 @@ class TestPlanSelectFromPredictor:
     def test_select_from_view_subselect_view(self):
         query = parse_sql('''
             select * from v1
-            where x1 in (select id from v2)
+            where x1 in (select v2.id from v2)
         ''', dialect='mindsdb')
 
         expected_plan = QueryPlan(
@@ -326,7 +326,7 @@ class TestPlanSelectFromPredictor:
                         where=BinaryOperation(
                             op='in',
                             args=[
-                                Identifier(parts=['v1', 'x1']),
+                                Identifier(parts=['x1']),
                                 Parameter(Result(0))
                             ]
                         )
@@ -408,7 +408,7 @@ class TestNestedSelect:
                     where=BinaryOperation(
                         op='=',
                         args=[
-                            Identifier(parts=['test_tabl', 'search_vector']),
+                            Identifier(parts=['search_vector']),
                             Parameter(Result(1))
                         ]
                     )
@@ -446,7 +446,7 @@ class TestNestedSelect:
             FetchDataframeStep(
                 step_num=0,
                 integration='chromadb',
-                query=parse_sql('SELECT test_tabl.content AS content FROM test_tabl LIMIT 1')
+                query=parse_sql('SELECT content AS content FROM test_tabl LIMIT 1')
             ),
             ApplyPredictorRowStep(
                 step_num=1,

--- a/tests/test_planner/test_ts_predictor.py
+++ b/tests/test_planner/test_ts_predictor.py
@@ -37,7 +37,7 @@ class TestJoinTimeseriesPredictor:
         expected_plan = QueryPlan(
             steps=[
                 FetchDataframeStep(integration='mysql',
-                                   query=Select(targets=[Identifier(parts=['ta', group_by_column], alias=Identifier(group_by_column))],
+                                   query=Select(targets=[Identifier(parts=[group_by_column], alias=Identifier(group_by_column))],
                                                 from_table=Identifier('data.ny_output', alias=Identifier('ta')),
                                                 distinct=True,
                                                 )
@@ -46,7 +46,7 @@ class TestJoinTimeseriesPredictor:
                               reduce='union',
                               step=FetchDataframeStep(integration='mysql',
                                    query=parse_sql("SELECT * FROM data.ny_output AS ta\
-                                    WHERE ta.pickup_hour is not null and ta.vendor_id = '$var[vendor_id]' ORDER BY ta.pickup_hour DESC")
+                                    WHERE pickup_hour is not null and vendor_id = '$var[vendor_id]' ORDER BY pickup_hour DESC")
                                    ),
                               ),
                 ApplyTimeseriesPredictorStep(namespace='mindsdb',
@@ -87,7 +87,7 @@ class TestJoinTimeseriesPredictor:
             steps=[
                 FetchDataframeStep(integration='mysql',
                                    query=Select(targets=[
-                                       Identifier(parts=['ta', group_by_column], alias=Identifier(group_by_column))],
+                                       Identifier(parts=[group_by_column], alias=Identifier(group_by_column))],
                                                 from_table=Identifier('data.ny_output', alias=Identifier('ta')),
                                                 distinct=True,
                                                 )
@@ -96,7 +96,7 @@ class TestJoinTimeseriesPredictor:
                               reduce='union',
                               step=FetchDataframeStep(integration='mysql',
                                                       query=parse_sql("SELECT * FROM data.ny_output AS ta\
-                                       WHERE ta.pickup_hour is not null and ta.vendor_id = '$var[vendor_id]' ORDER BY ta.pickup_hour DESC")
+                                       WHERE pickup_hour is not null and vendor_id = '$var[vendor_id]' ORDER BY pickup_hour DESC")
                                                       ),
                               ),
                 ApplyTimeseriesPredictorStep(namespace='mlflow',
@@ -140,7 +140,7 @@ class TestJoinTimeseriesPredictor:
         expected_plan = QueryPlan(
             steps=[
                 FetchDataframeStep(integration='mysql',
-                                   query=Select(targets=[Identifier(parts=['ta', group_by_column], alias=Identifier(group_by_column))],
+                                   query=Select(targets=[Identifier(parts=[group_by_column], alias=Identifier(group_by_column))],
                                                 from_table=Identifier('data.ny_output', alias=Identifier('ta')),
                                                 distinct=True,
                                                 )
@@ -149,7 +149,7 @@ class TestJoinTimeseriesPredictor:
                               reduce='union',
                               step=FetchDataframeStep(integration='mysql',
                                    query=parse_sql("SELECT * FROM data.ny_output AS ta\
-                                    WHERE ta.pickup_hour is not null and ta.vendor_id = '$var[vendor_id]' ORDER BY ta.pickup_hour DESC")
+                                    WHERE pickup_hour is not null and vendor_id = '$var[vendor_id]' ORDER BY pickup_hour DESC")
                                    ),
                               ),
                 ApplyTimeseriesPredictorStep(namespace='mindsdb',
@@ -193,7 +193,7 @@ class TestJoinTimeseriesPredictor:
             steps=[
                 FetchDataframeStep(integration='mysql',
                                    query=Select(targets=[
-                                       Identifier(parts=['ta', group_by_column], alias=Identifier(group_by_column))],
+                                       Identifier(parts=[group_by_column], alias=Identifier(group_by_column))],
                                                 from_table=Identifier('data.ny_output', alias=Identifier('ta')),
                                                 distinct=True,
                                                 )
@@ -203,7 +203,7 @@ class TestJoinTimeseriesPredictor:
                               step=FetchDataframeStep(
                                   integration='mysql',
                                   query=parse_sql("SELECT * FROM data.ny_output AS ta\
-                                   WHERE ta.pickup_hour is not null and ta.vendor_id = '$var[vendor_id]' ORDER BY ta.pickup_hour DESC")
+                                   WHERE pickup_hour is not null and vendor_id = '$var[vendor_id]' ORDER BY pickup_hour DESC")
                               ),
                 ),
                 ApplyTimeseriesPredictorStep(namespace='mindsdb',
@@ -248,9 +248,9 @@ class TestJoinTimeseriesPredictor:
             steps=[
                 FetchDataframeStep(integration='mysql',
                                    query=Select(targets=[
-                                       Identifier(parts=['ta', group_by_column], alias=Identifier(group_by_column))],
+                                       Identifier(parts=[group_by_column], alias=Identifier(group_by_column))],
                                                 from_table=Identifier('data.ny_output', alias=Identifier('ta')),
-                                                where=BinaryOperation('=', args=[Identifier('ta.vendor_id'), Constant(1)]),
+                                                where=BinaryOperation('=', args=[Identifier('vendor_id'), Constant(1)]),
                                                 distinct=True,
                                                 )
                                    ),
@@ -259,8 +259,8 @@ class TestJoinTimeseriesPredictor:
                               step=FetchDataframeStep(
                                   integration='mysql',
                                   query=parse_sql("SELECT * FROM data.ny_output AS ta\
-                                     WHERE ta.vendor_id = 1 AND ta.pickup_hour is not null and ta.vendor_id = '$var[vendor_id]' \
-                                     ORDER BY ta.pickup_hour DESC")
+                                     WHERE vendor_id = 1 AND pickup_hour is not null and vendor_id = '$var[vendor_id]' \
+                                     ORDER BY pickup_hour DESC")
                               ),
                 ),
                 ApplyTimeseriesPredictorStep(namespace='mindsdb',
@@ -308,9 +308,9 @@ class TestJoinTimeseriesPredictor:
             steps=[
                 FetchDataframeStep(integration='mysql',
                                    query=Select(targets=[
-                                       Identifier(parts=['ta', group_by_column], alias=Identifier(group_by_column))],
+                                       Identifier(parts=[group_by_column], alias=Identifier(group_by_column))],
                                        from_table=Identifier('data.ny_output', alias=Identifier('ta')),
-                                       where=BinaryOperation('=', args=[Identifier('ta.vendor_id'), Constant(1)]),
+                                       where=BinaryOperation('=', args=[Identifier('vendor_id'), Constant(1)]),
                                        distinct=True,
                                    )
                                    ),
@@ -319,12 +319,12 @@ class TestJoinTimeseriesPredictor:
                               step=FetchDataframeStep(
                                   integration='mysql',
                                   query=parse_sql(f"SELECT * FROM data.ny_output AS ta\
-                                    WHERE ta.vendor_id = 1 AND ta.pickup_hour is not null and ta.vendor_id = '$var[vendor_id]'\
-                                    ORDER BY ta.pickup_hour DESC LIMIT {predictor_window}")
+                                    WHERE vendor_id = 1 AND pickup_hour is not null and vendor_id = '$var[vendor_id]'\
+                                    ORDER BY pickup_hour DESC LIMIT {predictor_window}")
                                                       ),
                               ),
                 ApplyTimeseriesPredictorStep(
-                    output_time_filter=BinaryOperation('>', args=[Identifier('ta.pickup_hour'), Latest()]),
+                    output_time_filter=BinaryOperation('>', args=[Identifier('pickup_hour'), Latest()]),
                     namespace='mindsdb',
                     predictor=Identifier('tp3', alias=Identifier('tb')),
                     dataframe=Result(1),
@@ -363,8 +363,8 @@ class TestJoinTimeseriesPredictor:
         expected_plan = QueryPlan(
             steps=[
                 FetchDataframeStep(integration='mysql',
-                                   query=parse_sql("SELECT DISTINCT ta.vendor_id AS vendor_id FROM data.ny_output AS ta\
-                                                   WHERE ta.vendor_id = 1")
+                                   query=parse_sql("SELECT DISTINCT vendor_id AS vendor_id FROM data.ny_output AS ta\
+                                                   WHERE vendor_id = 1")
                                    ),
                 MapReduceStep(values=Result(0),
                               reduce='union',
@@ -374,22 +374,22 @@ class TestJoinTimeseriesPredictor:
                                       FetchDataframeStep(
                                           integration='mysql',
                                           query=parse_sql(f"SELECT * FROM data.ny_output AS ta \
-                                          WHERE ta.pickup_hour < 1 AND ta.vendor_id = 1 and ta.pickup_hour is not null \
-                                          AND ta.vendor_id = '$var[vendor_id]' \
-                                          ORDER BY ta.pickup_hour DESC LIMIT {predictor_window}"),
+                                          WHERE pickup_hour < 1 AND vendor_id = 1 and pickup_hour is not null \
+                                          AND vendor_id = '$var[vendor_id]' \
+                                          ORDER BY pickup_hour DESC LIMIT {predictor_window}"),
                                       ),
                                       FetchDataframeStep(
                                           integration='mysql',
                                           query=parse_sql("SELECT * FROM data.ny_output AS ta\
-                                           WHERE ta.pickup_hour BETWEEN 1 AND 10 AND ta.vendor_id = 1 and ta.pickup_hour is not null \
-                                            AND ta.vendor_id = '$var[vendor_id]' ORDER BY ta.pickup_hour DESC"),
+                                           WHERE pickup_hour BETWEEN 1 AND 10 AND vendor_id = 1 and pickup_hour is not null \
+                                            AND vendor_id = '$var[vendor_id]' ORDER BY pickup_hour DESC"),
                                       ),
 
                                   ]
                               )),
                 ApplyTimeseriesPredictorStep(
                     output_time_filter=BetweenOperation(
-                        args=[Identifier('ta.pickup_hour'), Constant(1), Constant(10)],
+                        args=[Identifier('pickup_hour'), Constant(1), Constant(10)],
                     ),
                     namespace='mindsdb',
                     predictor=Identifier('tp3', alias=Identifier('tb')),
@@ -431,9 +431,9 @@ class TestJoinTimeseriesPredictor:
             steps=[
                 FetchDataframeStep(integration='mysql',
                                    query=Select(targets=[
-                                       Identifier(parts=['ta', group_by_column], alias=Identifier(group_by_column))],
+                                       Identifier(parts=[group_by_column], alias=Identifier(group_by_column))],
                                        from_table=Identifier('data.ny_output', alias=Identifier('ta')),
-                                       where=BinaryOperation('=', args=[Identifier('ta.vendor_id'), Constant(1)]),
+                                       where=BinaryOperation('=', args=[Identifier('vendor_id'), Constant(1)]),
                                        distinct=True,
                                    )
                                    ),
@@ -445,19 +445,19 @@ class TestJoinTimeseriesPredictor:
                                       FetchDataframeStep(
                                           integration='mysql',
                                           query=parse_sql(f"SELECT * FROM data.ny_output AS ta \
-                                          WHERE ta.pickup_hour <= 10 AND ta.vendor_id = 1 and ta.pickup_hour is not null \
-                                          AND ta.vendor_id = '$var[vendor_id]' ORDER BY ta.pickup_hour DESC LIMIT {predictor_window}"),
+                                          WHERE pickup_hour <= 10 AND vendor_id = 1 and pickup_hour is not null \
+                                          AND vendor_id = '$var[vendor_id]' ORDER BY pickup_hour DESC LIMIT {predictor_window}"),
                                       ),
                                       FetchDataframeStep(
                                           integration='mysql',
                                           query=parse_sql("SELECT * FROM data.ny_output AS ta \
-                                          WHERE ta.pickup_hour > 10 AND ta.vendor_id = 1 and ta.pickup_hour is not null \
-                                          AND ta.vendor_id = '$var[vendor_id]' ORDER BY ta.pickup_hour DESC"),
+                                          WHERE pickup_hour > 10 AND vendor_id = 1 and pickup_hour is not null \
+                                          AND vendor_id = '$var[vendor_id]' ORDER BY pickup_hour DESC"),
                                       ),
 
                                   ]
                               )),
-                ApplyTimeseriesPredictorStep(output_time_filter=BinaryOperation('>', args=[Identifier('ta.pickup_hour'), Constant(10)]),
+                ApplyTimeseriesPredictorStep(output_time_filter=BinaryOperation('>', args=[Identifier('pickup_hour'), Constant(10)]),
                                              namespace='mindsdb',
                                              predictor=Identifier('tp3', alias=Identifier('tb')),
                                              dataframe=Result(1)),
@@ -498,9 +498,9 @@ class TestJoinTimeseriesPredictor:
                 FetchDataframeStep(
                     integration='mysql',
                     query=parse_sql('''
-                         select distinct ta.vendor_id as vendor_id, ta.type as type
+                         select distinct vendor_id as vendor_id, type as type
                          from data.ny_output as ta
-                         where ta.vendor_id = 1 and ta.type = 2
+                         where vendor_id = 1 and type = 2
                        ''')
                 ),
                 MapReduceStep(
@@ -512,22 +512,22 @@ class TestJoinTimeseriesPredictor:
                             FetchDataframeStep(
                                 integration='mysql',
                                 query=parse_sql(f"SELECT * FROM data.ny_output AS ta \
-                                  WHERE ta.pickup_hour <= 10 AND ta.vendor_id = 1 and ta.type = 2 and ta.pickup_hour is not null \
-                                  AND ta.vendor_id = '$var[vendor_id]' AND ta.type = '$var[type]'\
-                                  ORDER BY ta.pickup_hour DESC LIMIT {predictor_window}"),
+                                  WHERE pickup_hour <= 10 AND vendor_id = 1 and type = 2 and pickup_hour is not null \
+                                  AND vendor_id = '$var[vendor_id]' AND type = '$var[type]'\
+                                  ORDER BY pickup_hour DESC LIMIT {predictor_window}"),
                             ),
                             FetchDataframeStep(
                                 integration='mysql',
                                 query=parse_sql("SELECT * FROM data.ny_output AS ta \
-                                  WHERE ta.pickup_hour > 10 AND ta.vendor_id = 1 and ta.type = 2 and ta.pickup_hour is not null \
-                                  AND ta.vendor_id = '$var[vendor_id]' AND ta.type = '$var[type]'\
-                                  ORDER BY ta.pickup_hour DESC"),
+                                  WHERE pickup_hour > 10 AND vendor_id = 1 and type = 2 and pickup_hour is not null \
+                                  AND vendor_id = '$var[vendor_id]' AND type = '$var[type]'\
+                                  ORDER BY pickup_hour DESC"),
                             ),
 
                         ]
                     )),
                 ApplyTimeseriesPredictorStep(
-                    output_time_filter=BinaryOperation('>', args=[Identifier('ta.pickup_hour'), Constant(10)]),
+                    output_time_filter=BinaryOperation('>', args=[Identifier('pickup_hour'), Constant(10)]),
                     namespace='mindsdb',
                     predictor=Identifier('tp3', alias=Identifier('tb')),
                     dataframe=Result(1)),
@@ -567,9 +567,9 @@ class TestJoinTimeseriesPredictor:
             steps=[
                 FetchDataframeStep(integration='mysql',
                                    query=Select(targets=[
-                                       Identifier(parts=['ta', group_by_column], alias=Identifier(group_by_column))],
+                                       Identifier(parts=[group_by_column], alias=Identifier(group_by_column))],
                                        from_table=Identifier('data.ny_output', alias=Identifier('ta')),
-                                       where=BinaryOperation('=', args=[Identifier('ta.vendor_id'), Constant(1)]),
+                                       where=BinaryOperation('=', args=[Identifier('vendor_id'), Constant(1)]),
                                        distinct=True,
                                    )
                                    ),
@@ -581,19 +581,19 @@ class TestJoinTimeseriesPredictor:
                                       FetchDataframeStep(
                                           integration='mysql',
                                           query=parse_sql(f"SELECT * FROM data.ny_output AS ta\
-                                           WHERE ta.pickup_hour < 10 AND ta.vendor_id = 1 AND ta.pickup_hour is not null and\
-                                           ta.vendor_id = '$var[vendor_id]' ORDER BY ta.pickup_hour DESC LIMIT {predictor_window}"),
+                                           WHERE pickup_hour < 10 AND vendor_id = 1 AND pickup_hour is not null and\
+                                           vendor_id = '$var[vendor_id]' ORDER BY pickup_hour DESC LIMIT {predictor_window}"),
                                       ),
                                       FetchDataframeStep(
                                           integration='mysql',
                                           query=parse_sql("SELECT * FROM data.ny_output AS ta\
-                                           WHERE ta.pickup_hour >= 10 AND ta.vendor_id = 1 AND ta.pickup_hour is not null and\
-                                           ta.vendor_id = '$var[vendor_id]' ORDER BY ta.pickup_hour DESC"),
+                                           WHERE pickup_hour >= 10 AND vendor_id = 1 AND pickup_hour is not null and\
+                                           vendor_id = '$var[vendor_id]' ORDER BY pickup_hour DESC"),
                                       ),
 
                                   ]
                               )),
-                ApplyTimeseriesPredictorStep(output_time_filter=BinaryOperation('>=', args=[Identifier('ta.pickup_hour'), Constant(10)]),
+                ApplyTimeseriesPredictorStep(output_time_filter=BinaryOperation('>=', args=[Identifier('pickup_hour'), Constant(10)]),
                                              namespace='mindsdb',
                                              predictor=Identifier('tp3', alias=Identifier('tb')),
                                              dataframe=Result(1)),
@@ -633,9 +633,9 @@ class TestJoinTimeseriesPredictor:
             steps=[
                 FetchDataframeStep(integration='mysql',
                                    query=Select(targets=[
-                                       Identifier(parts=['ta', group_by_column], alias=Identifier(group_by_column))],
+                                       Identifier(parts=[group_by_column], alias=Identifier(group_by_column))],
                                        from_table=Identifier('data.ny_output', alias=Identifier('ta')),
-                                       where=BinaryOperation('=', args=[Identifier('ta.vendor_id'), Constant(1)]),
+                                       where=BinaryOperation('=', args=[Identifier('vendor_id'), Constant(1)]),
                                        distinct=True,
                                    )
                                    ),
@@ -644,13 +644,13 @@ class TestJoinTimeseriesPredictor:
                               step=FetchDataframeStep(
                                   integration='mysql',
                                   query=parse_sql("SELECT * FROM data.ny_output AS ta \
-                                  WHERE ta.pickup_hour < 10 AND ta.vendor_id = 1 AND ta.pickup_hour is not null and\
-                                  ta.vendor_id = '$var[vendor_id]' \
-                                  ORDER BY ta.pickup_hour DESC"),
+                                  WHERE pickup_hour < 10 AND vendor_id = 1 AND pickup_hour is not null and\
+                                  vendor_id = '$var[vendor_id]' \
+                                  ORDER BY pickup_hour DESC"),
                               ),
                 ),
                 ApplyTimeseriesPredictorStep(
-                    output_time_filter=BinaryOperation('<', args=[Identifier('ta.pickup_hour'), Constant(10)]),
+                    output_time_filter=BinaryOperation('<', args=[Identifier('pickup_hour'), Constant(10)]),
                     namespace='mindsdb',
                     predictor=Identifier('tp3', alias=Identifier('tb')),
                     dataframe=Result(1),
@@ -691,9 +691,9 @@ class TestJoinTimeseriesPredictor:
             steps=[
                 FetchDataframeStep(integration='mysql',
                                    query=Select(targets=[
-                                       Identifier(parts=['ta', group_by_column], alias=Identifier(group_by_column))],
+                                       Identifier(parts=[group_by_column], alias=Identifier(group_by_column))],
                                        from_table=Identifier('data.ny_output', alias=Identifier('ta')),
-                                       where=BinaryOperation('=', args=[Identifier('ta.vendor_id'), Constant(1)]),
+                                       where=BinaryOperation('=', args=[Identifier('vendor_id'), Constant(1)]),
                                        distinct=True,
                                    )
                                    ),
@@ -702,13 +702,13 @@ class TestJoinTimeseriesPredictor:
                               step=FetchDataframeStep(
                                   integration='mysql',
                                   query=parse_sql("SELECT * FROM data.ny_output AS ta\
-                                  WHERE  ta.pickup_hour <= 10 AND ta.vendor_id = 1 AND ta.pickup_hour is not null and\
-                                   ta.vendor_id = '$var[vendor_id]'\
-                                   ORDER BY ta.pickup_hour DESC"),
+                                  WHERE pickup_hour <= 10 AND vendor_id = 1 AND pickup_hour is not null and\
+                                   vendor_id = '$var[vendor_id]'\
+                                   ORDER BY pickup_hour DESC"),
                               ),
                 ),
                 ApplyTimeseriesPredictorStep(
-                    output_time_filter=BinaryOperation('<=', args=[Identifier('ta.pickup_hour'), Constant(10)]),
+                    output_time_filter=BinaryOperation('<=', args=[Identifier('pickup_hour'), Constant(10)]),
                     namespace='mindsdb',
                     predictor=Identifier('tp3', alias=Identifier('tb')),
                     dataframe=Result(1),
@@ -756,9 +756,9 @@ class TestJoinTimeseriesPredictor:
             steps=[
                 FetchDataframeStep(integration='mysql',
                                    query=Select(targets=[
-                                       Identifier(parts=['ta', group_by_column], alias=Identifier(group_by_column))],
+                                       Identifier(parts=[group_by_column], alias=Identifier(group_by_column))],
                                        from_table=Identifier('data.ny_output', alias=Identifier('ta')),
-                                       where=BinaryOperation('=', args=[Identifier('ta.vendor_id'), Constant(1)]),
+                                       where=BinaryOperation('=', args=[Identifier('vendor_id'), Constant(1)]),
                                        distinct=True,
                                    )
                                    ),
@@ -769,14 +769,14 @@ class TestJoinTimeseriesPredictor:
                         integration='mysql',
                         query=parse_sql("""
                             SELECT * FROM data.ny_output AS ta
-                            WHERE ta.pickup_hour <= 10 AND ta.vendor_id = 1 AND ta.pickup_hour is not null and
-                            ta.vendor_id = '$var[vendor_id]'
-                            ORDER BY ta.pickup_hour DESC LIMIT 10
+                            WHERE pickup_hour <= 10 AND vendor_id = 1 AND pickup_hour is not null and
+                            vendor_id = '$var[vendor_id]'
+                            ORDER BY pickup_hour DESC LIMIT 10
                         """),
                     ),
                 ),
                 ApplyTimeseriesPredictorStep(
-                    output_time_filter=BinaryOperation('>', args=[Identifier('ta.pickup_hour'), Constant(10)]),
+                    output_time_filter=BinaryOperation('>', args=[Identifier('pickup_hour'), Constant(10)]),
                     namespace='mindsdb',
                     predictor=Identifier('tp3', alias=Identifier('tb')),
                     dataframe=Result(1),
@@ -865,7 +865,7 @@ class TestJoinTimeseriesPredictor:
             default_namespace='mindsdb',
             steps=[
                 FetchDataframeStep(integration='mysql',
-                                   query=Select(targets=[Identifier(parts=['ta', group_by_column], alias=Identifier(group_by_column))],
+                                   query=Select(targets=[Identifier(parts=[group_by_column], alias=Identifier(group_by_column))],
                                                 from_table=Identifier('data.ny_output', alias=Identifier('ta')),
                                                 distinct=True,
                                                 )
@@ -874,7 +874,7 @@ class TestJoinTimeseriesPredictor:
                               reduce='union',
                               step=FetchDataframeStep(integration='mysql',
                                    query=parse_sql("SELECT * FROM data.ny_output AS ta\
-                                    WHERE ta.pickup_hour is not null and ta.vendor_id = '$var[vendor_id]' ORDER BY ta.pickup_hour DESC")
+                                    WHERE pickup_hour is not null and vendor_id = '$var[vendor_id]' ORDER BY pickup_hour DESC")
                                    ),
                               ),
                 ApplyTimeseriesPredictorStep(
@@ -920,7 +920,7 @@ class TestJoinTimeseriesPredictor:
             default_namespace='mysql',
             steps=[
                 FetchDataframeStep(integration='mysql',
-                                   query=Select(targets=[Identifier(parts=['ta', group_by_column], alias=Identifier(group_by_column))],
+                                   query=Select(targets=[Identifier(parts=[group_by_column], alias=Identifier(group_by_column))],
                                                 from_table=Identifier('data.ny_output', alias=Identifier('ta')),
                                                 distinct=True,
                                                 )
@@ -929,7 +929,7 @@ class TestJoinTimeseriesPredictor:
                               reduce='union',
                               step=FetchDataframeStep(integration='mysql',
                                    query=parse_sql("SELECT * FROM data.ny_output AS ta\
-                                    WHERE ta.pickup_hour is not null and ta.vendor_id = '$var[vendor_id]' ORDER BY ta.pickup_hour DESC")
+                                    WHERE pickup_hour is not null and vendor_id = '$var[vendor_id]' ORDER BY pickup_hour DESC")
                                    ),
                               ),
                 ApplyTimeseriesPredictorStep(
@@ -962,7 +962,7 @@ class TestJoinTimeseriesPredictor:
         for i in range(len(plan.steps)):
             assert plan.steps[i] == expected_plan.steps[i]
 
-    def test_timeseries_not_change_query(self):
+    def test_timeseries_planner_not_changes_query(self):
         sql = "select * from ds.data as ta left join mindsdb.pr as tb where ta.f2 in ('a') and ta.f1 > LATEST"
         query = parse_sql(sql,  dialect='mindsdb')
 
@@ -990,14 +990,14 @@ class TestJoinTimeseriesPredictor:
                 FetchDataframeStep(
                     integration='ds',
                     query=parse_sql(f"SELECT * FROM data.ny_output AS ta\
-                     WHERE ta.f1 is not null\
-                     ORDER BY ta.f1 DESC LIMIT {predictor_window}")
+                     WHERE f1 is not null\
+                     ORDER BY f1 DESC LIMIT {predictor_window}")
                 ),
                 ApplyTimeseriesPredictorStep(
                     namespace='mindsdb',
                     predictor=Identifier('pr', alias=Identifier('tb')),
                     dataframe=Result(0),
-                    output_time_filter=BinaryOperation('>', args=[Identifier('ta.f1'), Latest()]),
+                    output_time_filter=BinaryOperation('>', args=[Identifier('f1'), Latest()]),
                 ),
                 JoinStep(left=Result(0),
                          right=Result(1),
@@ -1048,21 +1048,21 @@ class TestJoinTimeseriesPredictor:
             default_namespace='ds',
             steps=[
                 FetchDataframeStep(integration='ds',
-                                   query=parse_sql("SELECT DISTINCT ta.f2 AS f2 FROM data.ny_output as ta\
-                                                    WHERE ta.f2 BETWEEN '2020-11-01' AND '2020-12-01'")),
+                                   query=parse_sql("SELECT DISTINCT f2 AS f2 FROM data.ny_output as ta\
+                                                    WHERE f2 BETWEEN '2020-11-01' AND '2020-12-01'")),
                 MapReduceStep(values=Result(0),
                               reduce='union',
                               step=FetchDataframeStep(
                                   integration='ds',
                                   query=parse_sql(f"SELECT * FROM data.ny_output as ta \
-                                                   WHERE ta.f2 BETWEEN '2020-11-01' AND '2020-12-01' \
-                                                   AND ta.f1 IS NOT NULL \
-                                                   AND ta.f2 = '$var[f2]' \
-                                                   ORDER BY ta.f1 DESC LIMIT {predictor_window}")
+                                                   WHERE f2 BETWEEN '2020-11-01' AND '2020-12-01' \
+                                                   AND f1 IS NOT NULL \
+                                                   AND f2 = '$var[f2]' \
+                                                   ORDER BY f1 DESC LIMIT {predictor_window}")
                               ),
                 ),
                 ApplyTimeseriesPredictorStep(
-                    output_time_filter=BinaryOperation('>', args=[Identifier('ta.f1'), Latest()]),
+                    output_time_filter=BinaryOperation('>', args=[Identifier('f1'), Latest()]),
                     namespace='mindsdb',
                     predictor=Identifier('pr', alias=Identifier('tb')),
                     dataframe=Result(1)),
@@ -1100,19 +1100,19 @@ class TestJoinTimeseriesPredictor:
             default_namespace='ds',
             steps=[
                 FetchDataframeStep(integration='ds',
-                                   query=parse_sql("SELECT DISTINCT ta.F2 AS F2, ta.f3 AS f3 FROM data.ny_output as ta\
-                                                    WHERE ta.f2 > '2020-11-01'")),
+                                   query=parse_sql("SELECT DISTINCT F2 AS F2, f3 AS f3 FROM data.ny_output as ta\
+                                                    WHERE f2 > '2020-11-01'")),
                 MapReduceStep(values=Result(0),
                               reduce='union',
                               step=FetchDataframeStep(
                                   integration='ds',
                                   query=parse_sql("SELECT * FROM data.ny_output AS ta\
-                                   WHERE ta.f2 > '2020-11-01' AND ta.F1 IS NOT NULL AND ta.F2 = '$var[F2]' AND ta.f3 = '$var[f3]'\
-                                   ORDER BY ta.F1 DESC LIMIT 3")
+                                   WHERE f2 > '2020-11-01' AND F1 IS NOT NULL AND F2 = '$var[F2]' AND f3 = '$var[f3]'\
+                                   ORDER BY F1 DESC LIMIT 3")
                               ),
                 ),
                 ApplyTimeseriesPredictorStep(
-                    output_time_filter=BinaryOperation('>', args=[Identifier('ta.f1'), Latest()]),
+                    output_time_filter=BinaryOperation('>', args=[Identifier('f1'), Latest()]),
                     namespace='mindsdb',
                     predictor=Identifier('pr', alias=Identifier('tb')),
                     dataframe=Result(1)),
@@ -1154,19 +1154,19 @@ class TestJoinTimeseriesPredictor:
                         FetchDataframeStep(
                             integration='files',
                             query=parse_sql(f"select * from schem.sweat as ta \
-                                             WHERE ta.date <= '2015-12-31' AND ta.date IS NOT NULL \
-                                             ORDER BY ta.date DESC LIMIT {predictor_window}"),
+                                             WHERE date <= '2015-12-31' AND date IS NOT NULL \
+                                             ORDER BY date DESC LIMIT {predictor_window}"),
                         ),
                         FetchDataframeStep(
                             integration='files',
                             query=parse_sql(f"select * from schem.sweat as ta \
-                                             WHERE ta.date > '2015-12-31' AND ta.date IS NOT NULL \
-                                             ORDER BY ta.date DESC"),
+                                             WHERE date > '2015-12-31' AND date IS NOT NULL \
+                                             ORDER BY date DESC"),
                         ),
                     ]
                 ),
                 ApplyTimeseriesPredictorStep(
-                    output_time_filter=BinaryOperation('>', args=[Identifier('ta.date'), Constant('2015-12-31')]),
+                    output_time_filter=BinaryOperation('>', args=[Identifier('date'), Constant('2015-12-31')]),
                     namespace='mindsdb',
                     predictor=Identifier('tp3', alias=Identifier('tb')),
                     dataframe=Result(0)),
@@ -1322,8 +1322,7 @@ class TestJoinTimeseriesPredictor:
             default_namespace='mindsdb'
         )
 
-        for i in range(len(plan.steps)):
-            assert plan.steps[i] == expected_plan.steps[i]
+        assert plan.steps == expected_plan.steps
 
     def test_several_groups(self):
 
@@ -1356,22 +1355,22 @@ class TestJoinTimeseriesPredictor:
             default_namespace='ds',
             steps=[
                 FetchDataframeStep(integration='ds',
-                                   query=parse_sql("SELECT DISTINCT t.type AS type, t.bedrooms AS bedrooms FROM HR_MA as t\
-                                                    WHERE t.type = 'house' AND t.bedrooms = 2")),
+                                   query=parse_sql("SELECT DISTINCT type AS type, bedrooms AS bedrooms FROM HR_MA as t\
+                                                    WHERE type = 'house' AND bedrooms = 2")),
                 MapReduceStep(values=Result(0),
                               reduce='union',
                               step=FetchDataframeStep(
                                   integration='ds',
                                   query=parse_sql(f"SELECT * FROM HR_MA as t \
-                                                   WHERE t.type = 'house' AND t.bedrooms = 2 \
-                                                   AND t.saledate IS NOT NULL \
-                                                   AND t.type = '$var[type]' \
-                                                   AND t.bedrooms = '$var[bedrooms]' \
-                                                   ORDER BY t.saledate DESC LIMIT {predictor_window}")
+                                                   WHERE type = 'house' AND bedrooms = 2 \
+                                                   AND saledate IS NOT NULL \
+                                                   AND type = '$var[type]' \
+                                                   AND bedrooms = '$var[bedrooms]' \
+                                                   ORDER BY saledate DESC LIMIT {predictor_window}")
                               ),
                 ),
                 ApplyTimeseriesPredictorStep(
-                    output_time_filter=BinaryOperation('>', args=[Identifier('t.saledate'), Latest()]),
+                    output_time_filter=BinaryOperation('>', args=[Identifier('saledate'), Latest()]),
                     namespace='mindsdb',
                     predictor=Identifier('pr', alias=Identifier('tb')),
                     dataframe=Result(1),
@@ -1429,21 +1428,21 @@ class TestJoinTimeseriesPredictor:
             default_namespace='ds',
             steps=[
                 FetchDataframeStep(integration='ds',
-                                   query=parse_sql("SELECT DISTINCT t.type AS type FROM HR_MA as t\
-                                                    WHERE t.type = 'house'")),
+                                   query=parse_sql("SELECT DISTINCT type AS type FROM HR_MA as t\
+                                                    WHERE type = 'house'")),
                 MapReduceStep(values=Result(0),
                               reduce='union',
                               step=FetchDataframeStep(
                                   integration='ds',
                                   query=parse_sql(f"SELECT * FROM HR_MA as t \
-                                                   WHERE t.type = 'house' \
-                                                   AND t.saledate IS NOT NULL \
-                                                   AND t.type = '$var[type]' \
-                                                   ORDER BY t.saledate DESC LIMIT {predictor_window}")
+                                                   WHERE type = 'house' \
+                                                   AND saledate IS NOT NULL \
+                                                   AND type = '$var[type]' \
+                                                   ORDER BY saledate DESC LIMIT {predictor_window}")
                               ),
                 ),
                 ApplyTimeseriesPredictorStep(
-                    output_time_filter=BinaryOperation('>', args=[Identifier('t.saledate'), Latest()]),
+                    output_time_filter=BinaryOperation('>', args=[Identifier('saledate'), Latest()]),
                     namespace='mindsdb',
                     predictor=Identifier('pr', alias=Identifier('tb')),
                     dataframe=Result(1)),
@@ -1491,7 +1490,7 @@ class TestJoinTimeseriesPredictor:
             FetchDataframeStep(
                 integration='int1',
                 query=Select(
-                    targets=[Identifier('t.type', alias=Identifier('type'))],
+                    targets=[Identifier('type', alias=Identifier('type'))],
                     from_table=NativeQuery(query='select * from tab', integration=Identifier('int1'), alias=Identifier('t')),
                     distinct=True
                 )
@@ -1505,10 +1504,10 @@ class TestJoinTimeseriesPredictor:
                         from_table=NativeQuery(query='select * from tab', integration=Identifier('int1'), alias=Identifier('t')),
                         distinct=False,
                         limit=Constant(10),
-                        order_by=[OrderBy(field=Identifier('t.date'), direction='DESC')],
+                        order_by=[OrderBy(field=Identifier('date'), direction='DESC')],
                         where=BinaryOperation('and', args=[
-                            BinaryOperation('is not', args=[Identifier('t.date'), NullConstant()]),
-                            BinaryOperation('=', args=[Identifier('t.type'), Constant('$var[type]')]),
+                            BinaryOperation('is not', args=[Identifier('date'), NullConstant()]),
+                            BinaryOperation('=', args=[Identifier('type'), Constant('$var[type]')]),
                         ])
                     )
                 ),
@@ -1517,7 +1516,7 @@ class TestJoinTimeseriesPredictor:
                 namespace='proj',
                 predictor=Identifier('pred', alias=Identifier('m')),
                 dataframe=Result(1),
-                output_time_filter=BinaryOperation('>', args=[Identifier('t.date'), Latest()]),
+                output_time_filter=BinaryOperation('>', args=[Identifier('date'), Latest()]),
             ),
             JoinStep(
                 left=Result(1),
@@ -1531,5 +1530,4 @@ class TestJoinTimeseriesPredictor:
         ])
 
         assert len(plan.steps) == len(expected_plan.steps)
-        for i in range(len(plan.steps)):
-            assert plan.steps[i] == expected_plan.steps[i]
+        assert plan.steps == expected_plan.steps


### PR DESCRIPTION
Support query current_timestamp in query:
```sql
select current_timestamp from my_pg.branches
```

Changes:
- Render: use special functions instead of identifier
- Planner
  - don't add aliases for selects from database
  - remove alias for ts conditions, they will be copied to other TS queries
