### PR TITLE
Support describe objects

### DIFF
--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -638,10 +638,23 @@ class MindsDBParser(Parser):
     def describe(self, p):
         return Describe(value=p.identifier)
 
-    @_('DESCRIBE PREDICTOR identifier',
-       'DESCRIBE MODEL identifier')
+    @_('DESCRIBE JOB identifier',
+       'DESCRIBE SKILL identifier',
+       'DESCRIBE CHATBOT identifier',
+       'DESCRIBE TRIGGER identifier',
+       'DESCRIBE KNOWLEDGE_BASE identifier',
+       'DESCRIBE PROJECT identifier',
+       'DESCRIBE ML_ENGINE identifier',
+       'DESCRIBE identifier identifier',
+       )
     def describe(self, p):
-        return Describe(value=p.identifier, type='predictor')
+        if isinstance(p[1], Identifier):
+            type = p[1].parts[-1]
+        else:
+            type = p[1]
+        type = type.replace(' ', '_')
+        return Describe(value=p[2], type=type)
+
 
     # USE
 

--- a/tests/test_parser/test_base_sql/test_describe.py
+++ b/tests/test_parser/test_base_sql/test_describe.py
@@ -20,7 +20,7 @@ class TestDescribeMindsdb:
     def test_describe_predictor(self):
         sql = "DESCRIBE PREDICTOR my_identifier"
         ast = parse_sql(sql, dialect='mindsdb')
-        expected_ast = Describe(type='predictor', value=Identifier('my_identifier'))
+        expected_ast = Describe(type='PREDICTOR', value=Identifier('my_identifier'))
 
         assert str(ast) == str(expected_ast)
         assert ast.to_tree() == expected_ast.to_tree()
@@ -28,6 +28,7 @@ class TestDescribeMindsdb:
         sql = "DESCRIBE MODEL my_identifier"
         ast = parse_sql(sql, dialect='mindsdb')
 
+        expected_ast = Describe(type='MODEL', value=Identifier('my_identifier'))
         assert str(ast) == str(expected_ast)
         assert ast.to_tree() == expected_ast.to_tree()
 
@@ -35,7 +36,7 @@ class TestDescribeMindsdb:
         sql = "DESCRIBE MODEL pred.attr"
         ast = parse_sql(sql, dialect='mindsdb')
 
-        expected_ast = Describe(type='predictor', value=Identifier(parts=['pred', 'attr']))
+        expected_ast = Describe(type='MODEL', value=Identifier(parts=['pred', 'attr']))
 
         assert str(ast) == str(expected_ast)
 
@@ -43,7 +44,7 @@ class TestDescribeMindsdb:
         sql = "DESCRIBE MODEL pred.11"
         ast = parse_sql(sql, dialect='mindsdb')
 
-        expected_ast = Describe(type='predictor', value=Identifier(parts=['pred', '11']))
+        expected_ast = Describe(type='MODEL', value=Identifier(parts=['pred', '11']))
 
         assert str(ast) == str(expected_ast)
 
@@ -51,8 +52,20 @@ class TestDescribeMindsdb:
         sql = "DESCRIBE MODEL pred.11.attr"
         ast = parse_sql(sql, dialect='mindsdb')
 
-        expected_ast = Describe(type='predictor', value=Identifier(parts=['pred', '11', 'attr']))
+        expected_ast = Describe(type='MODEL', value=Identifier(parts=['pred', '11', 'attr']))
 
         assert str(ast) == str(expected_ast)
 
+        # other objects
+        for obj in (
+                "AGENT", "JOB", "SKILL", "CHATBOT", "TRIGGER", "VIEW",
+                "KNOWLEDGE_BASE", "KNOWLEDGE BASE", "PREDICTOR", "MODEL",
+                'database', 'project', 'handler', 'ml_engine'):
 
+            sql = f"DESCRIBE {obj} aaa"
+            ast = parse_sql(sql, dialect='mindsdb')
+
+            obj = obj.replace(' ', '_')
+            expected_ast = Describe(type=obj, value=Identifier(parts=['aaa']))
+
+            assert str(ast) == str(expected_ast)


### PR DESCRIPTION
Support `describe <object type> <object name>`
Object type could be: AGENT / JOB / SKILL and others

Example: 
```sql
DESCRIBE VIEW v1
``