### PR TITLE
Model column mapping

### DIFF
--- a/mindsdb_sql/planner/steps.py
+++ b/mindsdb_sql/planner/steps.py
@@ -138,13 +138,20 @@ class FetchDataframeStep(PlanStep):
 
 class ApplyPredictorStep(PlanStep):
     """Applies a mindsdb predictor on some dataframe and returns a new dataframe with predictions"""
-    def __init__(self, namespace, predictor, dataframe, params=None, row_dict=None,  *args, **kwargs):
+    def __init__(self, namespace, predictor, dataframe, params: dict = None,
+                 row_dict: dict = None, columns_map: dict = None,  *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.namespace = namespace
         self.predictor = predictor
         self.dataframe = dataframe
         self.params = params
+
+        # columns to add to input data, struct: {column name: value}
         self.row_dict = row_dict
+
+        # rename columns in input data, struct: {a str: b Identifier}
+        #  renames b to a
+        self.columns_map = columns_map
 
         if isinstance(dataframe, Result):
             self.references.append(dataframe)


### PR DESCRIPTION
Mapping columns to model in joins

In this example
```sql
select * from db.table1 t
join my_model m on t.a = m.x
```

If table1 has:
```
a | b | c 
---------
1 | 2 | 3 
```

Column 'a' will be renamed to 'x' and my_model will receive input:
```
x | b | c 
---------
1 | 2 | 3 
```



Related to https://github.com/mindsdb/mindsdb/issues/4576