### PR TITLE
Fix update from select with using

### DIFF
--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -70,7 +70,6 @@ class MindsDBParser(Parser):
        'drop_dataset',
        'union',
        'select',
-       'select_using',
        'insert',
        'update',
        'delete',
@@ -1090,7 +1089,7 @@ class MindsDBParser(Parser):
         return OrderBy(field=p.identifier, direction='default')
 
     @_('select USING kw_parameter_list')
-    def select_using(self, p):
+    def select(self, p):
         p.select.using = p.kw_parameter_list
         return p.select
 

--- a/tests/test_parser/test_base_sql/test_update.py
+++ b/tests/test_parser/test_base_sql/test_update.py
@@ -56,6 +56,7 @@ class TestUpdateFromSelect:
             from                         
              (
                select result, prod_id from table1
+               USING  aaa = "bbb"
              ) as df
             where          
                 table2.prod_id = df.prod_id             
@@ -68,7 +69,8 @@ class TestUpdateFromSelect:
             },
             from_select=Select(
                 targets=[Identifier('result'), Identifier('prod_id')],
-                from_table=Identifier('table1')
+                from_table=Identifier('table1'),
+                using={'aaa': 'bbb'}
             ),
             from_select_alias=Identifier('df'),
             where=BinaryOperation(op='=', args=[


### PR DESCRIPTION
Fix for supporting using in update from select 
```sql
 UPDATE test_db.error_logs
    SET ai_explanation = prediction_data.completion
    FROM 
    (
        SELECT * FROM test_db.error_logs AS input
        USING  aaa = "bbb" --  <--
    ) AS prediction_data
    WHERE test_db.error_logs.id = prediction_data.id
```