### PR TITLE
Sqlalchemy render optimizations

### DIFF
--- a/mindsdb_sql/parser/ast/insert.py
+++ b/mindsdb_sql/parser/ast/insert.py
@@ -11,6 +11,7 @@ class Insert(ASTNode):
                  columns=None,
                  values=None,
                  from_select=None,
+                 is_plain=False,
                  *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.table = table
@@ -26,6 +27,9 @@ class Insert(ASTNode):
         # TODO require one of [values, from_select] is set
         self.values = values
         self.from_select = from_select
+
+        # True if values in query are constant (without subselects and operations)
+        self.is_plain = is_plain
 
     def to_column(self, col):
         if isinstance(col, str):

--- a/tests/test_render/test_sqlalchemyrender.py
+++ b/tests/test_render/test_sqlalchemyrender.py
@@ -184,5 +184,26 @@ class TestRender:
         sql2 = '''SELECT * FROM tb1 WHERE x IN ('2011-01-01 00:00:00', '2011-01-02 00:00:00')'''
         assert sql.replace('\n', '').replace('\t', '').replace('  ', ' ') == sql2
 
+    def test_exec_params(self):
+
+        values = [
+            [1, '2'],
+            [3, 'b'],
+        ]
+
+        query = Insert(
+            table=Identifier('tbl1'),
+            columns=[
+                Identifier('a'),
+                Identifier('b'),
+            ],
+            values=values,
+            is_plain=True
+        )
+
+        sql, params = SqlalchemyRender('mysql').get_exec_params(query, with_failback=False)
+
+        assert sql == '''INSERT INTO tbl1 (a, b) VALUES (%s, %s)'''
+        assert params == values
 
 


### PR DESCRIPTION
Changes:
- `get_exec_params` function:
  - alternative to `get_string` function
  - makes render query with params, output is sql and list of params: 
     - insert into table values  (%s, %s)
     - [[1,2], [3,4]]
- is_plain property of insert command
  - if is set - render can use it to extract params