### PR TITLE
Predict in partitions

### DIFF
--- a/mindsdb_sql/planner/steps.py
+++ b/mindsdb_sql/planner/steps.py
@@ -3,10 +3,8 @@ from mindsdb_sql.planner.step_result import Result
 
 
 class PlanStep:
-    def __init__(self, step_num=None, references=None):
+    def __init__(self, step_num=None):
         self.step_num = step_num
-        self.references = references or []
-        self.result_data = None
 
     @property
     def result(self):
@@ -45,8 +43,6 @@ class ProjectStep(PlanStep):
         self.dataframe = dataframe
         self.ignore_doubles = ignore_doubles
 
-        if isinstance(dataframe, Result):
-            self.references.append(dataframe)
 
 # TODO remove
 class FilterStep(PlanStep):
@@ -56,8 +52,6 @@ class FilterStep(PlanStep):
         self.dataframe = dataframe
         self.query = query
 
-        if isinstance(dataframe, Result):
-            self.references.append(dataframe)
 
 # TODO remove
 class GroupByStep(PlanStep):
@@ -69,9 +63,6 @@ class GroupByStep(PlanStep):
         self.columns = columns
         self.targets = targets
 
-        if isinstance(dataframe, Result):
-            self.references.append(dataframe)
-
 
 class JoinStep(PlanStep):
     """Joins two dataframes, producing a new dataframe"""
@@ -80,12 +71,6 @@ class JoinStep(PlanStep):
         self.left = left
         self.right = right
         self.query = query
-
-        if isinstance(left, Result):
-            self.references.append(left)
-
-        if isinstance(right, Result):
-            self.references.append(right)
 
 
 class UnionStep(PlanStep):
@@ -96,11 +81,6 @@ class UnionStep(PlanStep):
         self.right = right
         self.unique = unique
 
-        if isinstance(left, Result):
-            self.references.append(left)
-
-        if isinstance(right, Result):
-            self.references.append(right)
 
 # TODO remove
 class OrderByStep(PlanStep):
@@ -111,9 +91,6 @@ class OrderByStep(PlanStep):
         self.dataframe = dataframe
         self.order_by = order_by
 
-        if isinstance(dataframe, Result):
-            self.references.append(dataframe)
-
 
 class LimitOffsetStep(PlanStep):
     """Applies limit and offset to a dataframe"""
@@ -122,9 +99,6 @@ class LimitOffsetStep(PlanStep):
         self.dataframe = dataframe
         self.limit = limit
         self.offset = offset
-
-        if isinstance(dataframe, Result):
-            self.references.append(dataframe)
 
 
 class FetchDataframeStep(PlanStep):
@@ -152,9 +126,6 @@ class ApplyPredictorStep(PlanStep):
         # rename columns in input data, struct: {a str: b Identifier}
         #  renames b to a
         self.columns_map = columns_map
-
-        if isinstance(dataframe, Result):
-            self.references.append(dataframe)
 
 
 class ApplyTimeseriesPredictorStep(ApplyPredictorStep):

--- a/mindsdb_sql/planner/steps.py
+++ b/mindsdb_sql/planner/steps.py
@@ -166,18 +166,24 @@ class GetTableColumns(PlanStep):
 
 class MapReduceStep(PlanStep):
     """Applies a step for each value in a list, and then reduces results to a single dataframe"""
-    def __init__(self, values, step, reduce, *args, **kwargs):
+    def __init__(self, values, step, reduce='union', partition=None, *args, **kwargs):
+        """
+        :param values: input step data
+        :param step: step to be applied
+        :param reduce: type of reduce to be applied
+        :param partition: type of partition to be applied
+         - <number> - split data by chunks with equal size
+         - None - every record is variables to fill
+        """
         super().__init__(*args, **kwargs)
         self.values = values
         self.step = step
         self.reduce = reduce
-
-        if isinstance(values, Result):
-            self.references.append(values)
+        self.partition = partition
 
 
 class MultipleSteps(PlanStep):
-    def __init__(self, steps, reduce, *args, **kwargs):
+    def __init__(self, steps, reduce=None, *args, **kwargs):
         """Runs multiple steps and reduces results to a single dataframe"""
         super().__init__(*args, **kwargs)
         self.steps = steps

--- a/tests/test_planner/test_injected_data.py
+++ b/tests/test_planner/test_injected_data.py
@@ -4,7 +4,7 @@ from mindsdb_sql.parser.ast import *
 from mindsdb_sql.planner import plan_query
 from mindsdb_sql.planner.query_plan import QueryPlan
 from mindsdb_sql.planner.step_result import Result
-from mindsdb_sql.planner.steps import (FilterStep, DataStep, ProjectStep, JoinStep, ApplyPredictorStep,
+from mindsdb_sql.planner.steps import (DataStep, JoinStep, ApplyPredictorStep,
                                        SubSelectStep, QueryStep)
 from mindsdb_sql.parser.utils import JoinType
 

--- a/tests/test_planner/test_integration_select.py
+++ b/tests/test_planner/test_integration_select.py
@@ -37,7 +37,6 @@ class TestPlanIntegrationSelect:
                                                                           ])
                                                                       ),
                                                          step_num=0,
-                                                         references=None,
                                                          ),
                                   ])
 
@@ -361,7 +360,6 @@ class TestPlanIntegrationSelect:
                                                                           ])
                                                                       ),
                                                          step_num=0,
-                                                         references=None,
                                                          ),
                                   ])
 

--- a/tests/test_planner/test_join_predictor.py
+++ b/tests/test_planner/test_join_predictor.py
@@ -7,8 +7,8 @@ from mindsdb_sql.parser.ast import *
 from mindsdb_sql.planner import plan_query
 from mindsdb_sql.planner.query_plan import QueryPlan
 from mindsdb_sql.planner.step_result import Result
-from mindsdb_sql.planner.steps import (FetchDataframeStep, ProjectStep, JoinStep, ApplyPredictorStep, FilterStep,
-                                       LimitOffsetStep, QueryStep, SubSelectStep, ApplyPredictorRowStep)
+from mindsdb_sql.planner.steps import (FetchDataframeStep, ProjectStep, JoinStep, ApplyPredictorStep,
+                                       QueryStep, SubSelectStep, ApplyPredictorRowStep)
 from mindsdb_sql.parser.utils import JoinType
 from mindsdb_sql import parse_sql
 

--- a/tests/test_planner/test_join_predictor.py
+++ b/tests/test_planner/test_join_predictor.py
@@ -445,7 +445,7 @@ class TestPredictorWithUsing:
         expected_plan = QueryPlan(
             steps=[
                 FetchDataframeStep(integration='int', raw_query='select * from tab1'),
-                SubSelectStep(step_num=1, references=[], query=Select(targets=[Star()]),
+                SubSelectStep(step_num=1, query=Select(targets=[Star()]),
                               dataframe=Result(0), table_name='t'),
                 ApplyPredictorStep(namespace='mindsdb', dataframe=Result(1),
                                    predictor=Identifier('pred'), params={'a': 1}),

--- a/tests/test_planner/test_join_tables.py
+++ b/tests/test_planner/test_join_tables.py
@@ -7,8 +7,7 @@ from mindsdb_sql.parser.ast import *
 from mindsdb_sql.planner import plan_query
 from mindsdb_sql.planner.query_plan import QueryPlan
 from mindsdb_sql.planner.step_result import Result
-from mindsdb_sql.planner.steps import (FetchDataframeStep, ProjectStep, FilterStep, JoinStep, GroupByStep,
-                                       LimitOffsetStep, OrderByStep, ApplyPredictorStep, SubSelectStep, QueryStep)
+from mindsdb_sql.planner.steps import (FetchDataframeStep, ProjectStep, JoinStep, ApplyPredictorStep, SubSelectStep, QueryStep)
 from mindsdb_sql.parser.utils import JoinType
 from mindsdb_sql import parse_sql
 

--- a/tests/test_planner/test_join_tables.py
+++ b/tests/test_planner/test_join_tables.py
@@ -433,7 +433,7 @@ class TestPlanJoinTables:
         expected_plan = QueryPlan(
             steps=[
                 FetchDataframeStep(integration='int1', raw_query='select raw query'),
-                SubSelectStep(step_num=1, references=[], query=Select(targets=[Star()]), dataframe=Result(0), table_name='t1'),
+                SubSelectStep(step_num=1, query=Select(targets=[Star()]), dataframe=Result(0), table_name='t1'),
                 ApplyPredictorStep(namespace='proj', dataframe=Result(1),
                                    predictor=Identifier('pred', alias=Identifier('m'))),
                 JoinStep(left=Result(1),

--- a/tests/test_planner/test_mindsdb_predictors_select.py
+++ b/tests/test_planner/test_mindsdb_predictors_select.py
@@ -1,13 +1,8 @@
-import pytest
 
-from mindsdb_sql import parse_sql
-from mindsdb_sql.exceptions import PlanningException
 from mindsdb_sql.parser.ast import *
 from mindsdb_sql.planner import plan_query
 from mindsdb_sql.planner.query_plan import QueryPlan
-from mindsdb_sql.planner.step_result import Result
-from mindsdb_sql.planner.steps import (FetchDataframeStep, ProjectStep, FilterStep, JoinStep, ApplyPredictorStep,
-                                       ApplyPredictorRowStep, GroupByStep)
+from mindsdb_sql.planner.steps import (FetchDataframeStep)
 
 
 class TestPlanPredictorsSelect:

--- a/tests/test_planner/test_mindsdb_predictors_select.py
+++ b/tests/test_planner/test_mindsdb_predictors_select.py
@@ -32,7 +32,6 @@ class TestPlanPredictorsSelect:
                                                                           ])
                                                                       ),
                                                          step_num=0,
-                                                         references=None,
                                                          ),
                                   ])
 


### PR DESCRIPTION
Updated planner to support option to plan query with partitions
To enable it the 'partition_size' param should be used:
```sql
  select * from int.tab1 a
    join proj.pred1 p1          
   using partition_size=1000   
```
It will:
- fetch all from `int.tab1`
- split data by 1000 rows chunks 
- execute ApplyPredictorStep and JoinStep for every chunk

For now only ApplyPredictorStep and JoinStep could be used in partition
