### PR TITLE
Fix precedence of 'not in'

### DIFF
--- a/mindsdb_sql/parser/dialects/mindsdb/lexer.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/lexer.py
@@ -72,7 +72,7 @@ class MindsDBLexer(Lexer):
         PLUS, MINUS, DIVIDE, MODULO,
         EQUALS, NEQUALS, GREATER, GEQ, LESS, LEQ,
         AND, OR, NOT, IS, IS_NOT,
-        IN, LIKE, NOT_LIKE, CONCAT, BETWEEN, WINDOW, OVER, PARTITION_BY,
+        IN, NOT_IN, LIKE, NOT_LIKE, CONCAT, BETWEEN, WINDOW, OVER, PARTITION_BY,
         JSON_GET, JSON_GET_STR, INTERVAL,
 
         # Data types
@@ -281,6 +281,7 @@ class MindsDBLexer(Lexer):
     OR = r'\bOR\b'
     IS_NOT = r'\bIS[\s]+NOT\b'
     NOT_LIKE = r'\bNOT[\s]+LIKE\b'
+    NOT_IN = r'\bNOT[\s]+IN\b'
     NOT = r'\bNOT\b'
     IS = r'\bIS\b'
     LIKE = r'\bLIKE\b'

--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -43,7 +43,7 @@ class MindsDBParser(Parser):
         ('left', AND),
         ('right', UNOT),
         ('left', EQUALS, NEQUALS),
-        ('nonassoc', LESS, LEQ, GREATER, GEQ, IN, BETWEEN, IS, IS_NOT, NOT_LIKE, LIKE),
+        ('nonassoc', LESS, LEQ, GREATER, GEQ, IN, NOT_IN, BETWEEN, IS, IS_NOT, NOT_LIKE, LIKE),
         ('left', JSON_GET),
         ('left', PLUS, MINUS),
         ('left', STAR, DIVIDE),
@@ -1407,11 +1407,6 @@ class MindsDBParser(Parser):
     def star(self, p):
         return Star()
 
-    @_('expr NOT IN expr')
-    def expr(self, p):
-        op = p[1] + ' ' + p[2]
-        return BinaryOperation(op=op, args=(p.expr0, p.expr1))
-
     @_('expr PLUS expr',
        'expr MINUS expr',
        'expr STAR expr',
@@ -1435,7 +1430,8 @@ class MindsDBParser(Parser):
        'expr CONCAT expr',
        'expr JSON_GET constant',
        'expr JSON_GET_STR constant',
-       'expr IN expr')
+       'expr NOT_IN expr',
+       'expr IN expr',)
     def expr(self, p):
         if hasattr(p, 'LAST'):
             arg1 = Last()

--- a/tests/test_parser/test_base_sql/test_select_structure.py
+++ b/tests/test_parser/test_base_sql/test_select_structure.py
@@ -814,7 +814,7 @@ class TestSelectStructure:
         assert str(ast) == str(expected_ast)
         assert ast.to_tree() == expected_ast.to_tree()
 
-    def test_where_precedence(self, dialect):
+    def test_is_not_precedence(self, dialect):
         query = "select * from t1 where a is not null and b = c"
         expected_ast = Select(
             targets=[Star()],
@@ -1036,3 +1036,23 @@ class TestMindsdb:
 
         assert ast.to_tree() == expected_ast.to_tree()
         assert str(ast) == str(expected_ast)
+
+    def test_not_in_precedence(self):
+        query = "select * from t1 where a = 1 and b not in (1, 2)"
+        expected_ast = Select(
+            targets=[Star()],
+            from_table=Identifier('t1'),
+            where=BinaryOperation(op='and', args=[
+                BinaryOperation(op='=', args=[
+                    Identifier('a'),
+                    Constant(1)
+                ]),
+                BinaryOperation(op='not in', args=[
+                    Identifier('b'),
+                    Tuple([Constant(1), Constant(2)])
+                ]),
+            ])
+        )
+        ast = parse_sql(query)
+        assert str(ast) == str(expected_ast)
+        assert ast.to_tree() == expected_ast.to_tree()


### PR DESCRIPTION

Fixing wrong precedence of 'not in' operator

fixes #384