### PR TITLE
Support different casting

### DIFF
--- a/mindsdb_sql/parser/dialects/mindsdb/lexer.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/lexer.py
@@ -71,12 +71,12 @@ class MindsDBLexer(Lexer):
         # Operators
         PLUS, MINUS, MATCH, NOT_MATCH, DIVIDE, MODULO,
         EQUALS, NEQUALS, GREATER, GEQ, LESS, LEQ,
-        AND, OR, NOT, IS, IS_NOT,
+        AND, OR, NOT, IS, IS_NOT, TYPECAST,
         IN, NOT_IN, LIKE, NOT_LIKE, CONCAT, BETWEEN, WINDOW, OVER, PARTITION_BY,
         JSON_GET, JSON_GET_STR, INTERVAL,
 
         # Data types
-        CAST, ID, INTEGER, FLOAT, QUOTE_STRING, DQUOTE_STRING, NULL, TRUE, FALSE,
+        CAST, ID, INTEGER, DATE, FLOAT, QUOTE_STRING, DQUOTE_STRING, NULL, TRUE, FALSE,
 
     }
 
@@ -148,6 +148,7 @@ class MindsDBLexer(Lexer):
     CONVERT = r'\bCONVERT\b'
     DESCRIBE = r'\bDESCRIBE\b'
     BEGIN = r'\bBEGIN\b'
+    DATE = r'\bDATE\b'
 
     # SHOW
     SHOW = r'\bSHOW\b'
@@ -251,6 +252,7 @@ class MindsDBLexer(Lexer):
     VALUES = r'\bVALUES\b'
 
     # Special
+    TYPECAST = r'\:\:'
     DOT = r'\.'
     COMMA = r','
     LPAREN = r'\('

--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -1421,6 +1421,15 @@ class MindsDBParser(Parser):
     def expr(self, p):
         return TypeCast(arg=p.expr, type_name=str(p.id))
 
+    @_('DATE string')
+    def expr(self, p):
+        return TypeCast(arg=Constant(p.string), type_name=p.DATE)
+
+    @_('expr TYPECAST id')
+    @_('expr TYPECAST DATE')
+    def expr(self, p):
+        return TypeCast(arg=p.expr, type_name=p[2])
+
     @_('enumeration')
     def expr_list(self, p):
         return p.enumeration
@@ -1652,6 +1661,7 @@ class MindsDBParser(Parser):
     @_('ID',
        'BEGIN',
        'CAST',
+       'DATE',
        'CHANNEL',
        'CHARSET',
        'CODE',

--- a/tests/test_parser/test_base_sql/test_select_structure.py
+++ b/tests/test_parser/test_base_sql/test_select_structure.py
@@ -1094,3 +1094,35 @@ class TestMindsdb:
 
             ast = parse_sql(sql)
             assert str(ast) == str(expected_ast)
+
+    def test_alternative_casting(self):
+
+        # int
+        expected_ast = Select(targets=[
+            TypeCast(type_name='int64', arg=Constant('1998')),
+            TypeCast(type_name='int64', arg=Identifier('col1'), alias=Identifier('col2'))
+        ])
+
+        sql = f"SELECT '1998'::int64, col1::int64 col2"
+        ast = parse_sql(sql)
+        assert str(ast) == str(expected_ast)
+
+        # date
+        expected_ast = Select(targets=[
+            TypeCast(type_name='date', arg=Constant('1998-12-01')),
+            TypeCast(type_name='date', arg=Identifier('col1'), alias=Identifier('col2'))
+        ])
+
+        sql = f"SELECT '1998-12-01'::date, col1::date col2"
+        ast = parse_sql(sql)
+        assert str(ast) == str(expected_ast)
+
+        #
+        expected_ast = Select(targets=[
+            TypeCast(type_name='date', arg=Constant('1998-12-01')),
+        ])
+
+        sql = f"SELECT date '1998-12-01'"
+        ast = parse_sql(sql)
+        assert str(ast) == str(expected_ast)
+

--- a/tests/test_parser/test_base_sql/test_select_structure.py
+++ b/tests/test_parser/test_base_sql/test_select_structure.py
@@ -1099,30 +1099,30 @@ class TestMindsdb:
 
         # int
         expected_ast = Select(targets=[
-            TypeCast(type_name='int64', arg=Constant('1998')),
-            TypeCast(type_name='int64', arg=Identifier('col1'), alias=Identifier('col2'))
+            TypeCast(type_name='CHAR', arg=Constant('1998')),
+            TypeCast(type_name='CHAR', arg=Identifier('col1'), alias=Identifier('col2'))
         ])
 
-        sql = f"SELECT '1998'::int64, col1::int64 col2"
+        sql = f"SELECT '1998'::CHAR, col1::CHAR col2"
         ast = parse_sql(sql)
         assert str(ast) == str(expected_ast)
 
         # date
         expected_ast = Select(targets=[
-            TypeCast(type_name='date', arg=Constant('1998-12-01')),
-            TypeCast(type_name='date', arg=Identifier('col1'), alias=Identifier('col2'))
+            TypeCast(type_name='DATE', arg=Constant('1998-12-01')),
+            TypeCast(type_name='DATE', arg=Identifier('col1'), alias=Identifier('col2'))
         ])
 
-        sql = f"SELECT '1998-12-01'::date, col1::date col2"
+        sql = f"SELECT '1998-12-01'::DATE, col1::DATE col2"
         ast = parse_sql(sql)
         assert str(ast) == str(expected_ast)
 
         #
         expected_ast = Select(targets=[
-            TypeCast(type_name='date', arg=Constant('1998-12-01')),
+            TypeCast(type_name='DATE', arg=Constant('1998-12-01')),
         ])
 
-        sql = f"SELECT date '1998-12-01'"
+        sql = f"SELECT DATE '1998-12-01'"
         ast = parse_sql(sql)
         assert str(ast) == str(expected_ast)
 


### PR DESCRIPTION
New supported syntax:
- select date '1998-12-01'
- select '1998-12-01'::date
