### PR TITLE
Support expressions in order_by

### DIFF
--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -207,13 +207,13 @@ class MindsDBParser(Parser):
 
     # -- triggers --
     @_('CREATE TRIGGER identifier ON identifier LPAREN raw_query RPAREN')
-    @_('CREATE TRIGGER identifier ON identifier COLUMNS ordering_terms LPAREN raw_query RPAREN')
+    @_('CREATE TRIGGER identifier ON identifier COLUMNS column_list LPAREN raw_query RPAREN')
     def create_trigger(self, p):
         query_str = tokens_to_string(p.raw_query)
 
         columns = None
-        if hasattr(p, 'ordering_terms'):
-            columns = [i.field for i in p.ordering_terms]
+        if hasattr(p, 'column_list'):
+            columns = [Identifier(i) for i in p.column_list]
 
         return CreateTrigger(
             name=p.identifier0,

--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -1116,17 +1116,21 @@ class MindsDBParser(Parser):
         p.ordering_term.nulls = p.NULLS_LAST
         return p.ordering_term
 
-    @_('identifier DESC')
+    @_('ordering_term DESC')
     def ordering_term(self, p):
-        return OrderBy(field=p.identifier, direction='DESC')
+        item = p.ordering_term
+        item.direction = 'DESC'
+        return item
 
-    @_('identifier ASC')
+    @_('ordering_term ASC')
     def ordering_term(self, p):
-        return OrderBy(field=p.identifier, direction='ASC')
+        item = p.ordering_term
+        item.direction = 'ASC'
+        return item
 
-    @_('identifier')
+    @_('expr')
     def ordering_term(self, p):
-        return OrderBy(field=p.identifier, direction='default')
+        return OrderBy(field=p.expr, direction='default')
 
     @_('select USING kw_parameter_list')
     def select(self, p):

--- a/tests/test_parser/test_base_sql/test_select_operations.py
+++ b/tests/test_parser/test_base_sql/test_select_operations.py
@@ -614,7 +614,7 @@ class TestOperationsMindsdb:
                     select * from db.item
                     where l_orderkey = o_orderkey
                   )
-                group by orderpriority
+                group by max(orderpriority)
             '''
             ast = parse_sql(sql)
 
@@ -631,7 +631,7 @@ class TestOperationsMindsdb:
                         ])
                     ))
                 ]),
-                group_by=[Identifier('orderpriority')],
+                group_by=[Function(op='max', args=[Identifier('orderpriority')])],
             )
 
             assert str(ast) == str(expected_ast)


### PR DESCRIPTION
Parser: 
Support expression in order by clause:
```sql
select *
from tbl
order by a*b -- <--
```