### PR TITLE
Fixes parsing quotes

### DIFF
--- a/mindsdb_sql/parser/dialects/mindsdb/lexer.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/lexer.py
@@ -317,9 +317,9 @@ class MindsDBLexer(Lexer):
     def INTEGER(self, t):
         return t
 
-    @_(r"'(?:\\.|[^'])*'")
+    @_(r"'(?:\\.|[^'])*(?:''(?:\\.|[^'])*)*'")
     def QUOTE_STRING(self, t):
-        t.value = t.value.replace('\\"', '"').replace("\\'", "'")
+        t.value = t.value.replace('\\"', '"').replace("\\'", "'").replace("''", "'")
         return t
 
     @_(r'"(?:\\.|[^"])*"')

--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -1676,6 +1676,7 @@ class MindsDBParser(Parser):
 
     @_('identifier DOT identifier',
        'identifier DOT integer',
+       'identifier DOT dquote_string',
        'identifier DOT star')
     def identifier(self, p):
         node = p[0]
@@ -1683,6 +1684,8 @@ class MindsDBParser(Parser):
             node.parts.append(p[2])
         elif isinstance(p[2], int):
             node.parts.append(str(p[2]))
+        elif isinstance(p[2], str):
+            node.parts.append(p[2])
         else:
             node.parts += p[2].parts
         return node

--- a/tests/test_parser/test_base_sql/test_base_sql.py
+++ b/tests/test_parser/test_base_sql/test_base_sql.py
@@ -73,3 +73,16 @@ b"
         assert str(ast).lower() == str(expected_ast).lower()
         assert ast.to_tree() == expected_ast.to_tree()
 
+    def test_quotes_identifier(self):
+        sql = 'select t2."var (k)" from t2'
+
+        expected_ast = Select(
+            targets=[
+                Identifier(parts=['t2', 'var (k)'])
+            ],
+            from_table=Identifier('t2')
+        )
+        ast = parse_sql(sql)
+
+        assert str(ast).lower() == str(expected_ast).lower()
+        assert ast.to_tree() == expected_ast.to_tree()

--- a/tests/test_parser/test_base_sql/test_base_sql.py
+++ b/tests/test_parser/test_base_sql/test_base_sql.py
@@ -60,5 +60,16 @@ b"
         assert str(ast).lower() == str(expected_ast).lower()
         assert ast.to_tree() == expected_ast.to_tree()
 
+    def test_quotes_escaping(self):
+        sql = "select 'women''s soccer'"
 
+        expected_ast = Select(
+            targets=[
+                Constant(value="women's soccer")
+            ]
+        )
+        ast = parse_sql(sql)
+
+        assert str(ast).lower() == str(expected_ast).lower()
+        assert ast.to_tree() == expected_ast.to_tree()
 


### PR DESCRIPTION
Fixes:
- fix quote is escaped by quote
  - example `women''s soccer`
- fix double quoted part of identifier
  - example `t2."var (k)"` 