### PR TITLE
Support double-quoted identifier

### DIFF
--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -1691,15 +1691,15 @@ class MindsDBParser(Parser):
             node.parts += p[2].parts
         return node
 
-    @_('id')
-    def identifier(self, p):
-        value = p[0]
-        return Identifier.from_path_str(value)
-
     @_('quote_string',
        'dquote_string')
     def string(self, p):
         return p[0]
+
+    @_('id', 'dquote_string')
+    def identifier(self, p):
+        value = p[0]
+        return Identifier.from_path_str(value)
 
     @_('PARAMETER')
     def parameter(self, p):

--- a/mindsdb_sql/render/sqlalchemy_render.py
+++ b/mindsdb_sql/render/sqlalchemy_render.py
@@ -293,11 +293,10 @@ class SqlalchemyRender:
             conditions.append(
                 (self.to_expression(condition), self.to_expression(result))
             )
-        else_ = None
         if t.default is not None:
-            else_ = self.to_expression(t.default)
+            conditions.append(self.to_expression(t.default))
 
-        return sa.case(conditions, else_=else_)
+        return sa.case(*conditions)
 
     def to_function(self, t):
         op = getattr(sa.func, t.op)

--- a/tests/test_parser/test_base_sql/test_select_structure.py
+++ b/tests/test_parser/test_base_sql/test_select_structure.py
@@ -1124,3 +1124,13 @@ class TestMindsdb:
         ast = parse_sql(sql)
         assert str(ast) == str(expected_ast)
 
+    def test_table_double_quote(self):
+        expected_ast = Select(
+            targets=[Identifier('account_id')],
+            from_table=Identifier(parts=['order'])
+        )
+
+        sql = 'select account_id from "order"'
+
+        ast = parse_sql(sql)
+        assert str(ast) == str(expected_ast)

--- a/tests/test_render/test_sqlalchemyrender.py
+++ b/tests/test_render/test_sqlalchemyrender.py
@@ -74,6 +74,7 @@ def parse_sql2(sql, dialect='mindsdb'):
         or 'current_user()' in sql  # replaced to CURRENT_USER
         or 'user()' in sql  # replaced to USER
         or 'not exists' in sql  # replaced to not(exits(
+        or "WHEN R.DELETE_RULE = 'CASCADE'" in sql # wrapped in parens by sqlalchemy
     ):
 
         # sqlalchemy could add own aliases for constant


### PR DESCRIPTION
Support identifier in qoutes

```sql
select account_id from "order"
```