### PR TITLE
Support LAST in function

### DIFF
--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -1416,6 +1416,14 @@ class MindsDBParser(Parser):
             args = p.expr_list_or_nothing
         if not args:
             args = []
+        for i, arg in enumerate(args):
+            if (
+                    isinstance(arg, Identifier)
+                    and len(arg.parts) == 1
+                    and arg.parts[0].lower() == 'last'
+            ):
+                args[i] = Last()
+
         namespace = None
         if hasattr(p, 'identifier'):
             if len(p.identifier.parts) > 1:

--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -46,7 +46,7 @@ class MindsDBParser(Parser):
         ('nonassoc', LESS, LEQ, GREATER, GEQ, IN, NOT_IN, BETWEEN, IS, IS_NOT, NOT_LIKE, LIKE),
         ('left', JSON_GET),
         ('left', PLUS, MINUS),
-        ('left', STAR, DIVIDE),
+        ('left', STAR, DIVIDE, TYPECAST),
         ('right', UMINUS),  # Unary minus operator, unary not
 
     )

--- a/tests/test_parser/test_base_sql/test_select_structure.py
+++ b/tests/test_parser/test_base_sql/test_select_structure.py
@@ -1106,12 +1106,22 @@ class TestMindsdb:
         assert str(ast) == str(expected_ast)
 
         # date
-        expected_ast = Select(targets=[
-            TypeCast(type_name='DATE', arg=Constant('1998-12-01')),
-            TypeCast(type_name='DATE', arg=Identifier('col1'), alias=Identifier('col2'))
-        ])
+        expected_ast = Select(
+            targets=[
+                TypeCast(type_name='DATE', arg=Constant('1998-12-01')),
+                BinaryOperation(op='+', args=[
+                    Identifier('col0'),
+                    TypeCast(type_name='DATE', arg=Identifier('col1'), alias=Identifier('col2')),
+                ])
+            ],
+            from_table=Identifier('t1'),
+            where=BinaryOperation(op='>', args=[
+                Identifier('col0'),
+                TypeCast(type_name='DATE', arg=Identifier('col1')),
+            ])
+        )
 
-        sql = f"SELECT '1998-12-01'::DATE, col1::DATE col2"
+        sql = f"SELECT '1998-12-01'::DATE, col0 + col1::DATE col2 from t1 where col0 > col1::DATE"
         ast = parse_sql(sql)
         assert str(ast) == str(expected_ast)
 

--- a/tests/test_parser/test_mindsdb/test_selects.py
+++ b/tests/test_parser/test_mindsdb/test_selects.py
@@ -121,21 +121,32 @@ class TestSpecificSelects:
         assert ast.to_tree() == expected_ast.to_tree()
         assert str(ast) == str(expected_ast)
 
-
     def test_last(self):
-        sql = """SELECT * FROM t1 t where t.id>last"""
+        sql = """SELECT * FROM t1 t where t.id>last and t.x > coalence(last, 0)"""
 
         ast = parse_sql(sql, dialect='mindsdb')
         expected_ast = Select(
             targets=[Star()],
             from_table=Identifier(parts=['t1'], alias=Identifier('t')),
-            where=BinaryOperation(
-              op='>',
-              args=[
-                  Identifier(parts=['t', 'id']),
-                  Last()
-              ]
-            )
+            where=BinaryOperation(op='and', args=[
+                BinaryOperation(
+                  op='>',
+                  args=[
+                      Identifier(parts=['t', 'id']),
+                      Last()
+                  ]
+                ),
+                BinaryOperation(
+                  op='>',
+                  args=[
+                      Identifier(parts=['t', 'x']),
+                      Function(op='coalence', args=[
+                          Last(),
+                          Constant(0)
+                      ])
+                  ]
+                ),
+            ])
         )
 
         assert ast.to_tree() == expected_ast.to_tree()


### PR DESCRIPTION
Changes:
- Support LAST as argument of function
Example:
```sql
SELECT * FROM t1 
where id > coalesce(last, 0)
```

Fixes:
- Fix precedence of '::' operator (type cast)