### PR TITLE
Fix modulo precedence

### DIFF
--- a/mindsdb_sql/parser/dialects/mindsdb/parser.py
+++ b/mindsdb_sql/parser/dialects/mindsdb/parser.py
@@ -46,7 +46,7 @@ class MindsDBParser(Parser):
         ('nonassoc', LESS, LEQ, GREATER, GEQ, IN, NOT_IN, BETWEEN, IS, IS_NOT, NOT_LIKE, LIKE),
         ('left', JSON_GET),
         ('left', PLUS, MINUS),
-        ('left', STAR, DIVIDE, TYPECAST),
+        ('left', STAR, DIVIDE, TYPECAST, MODULO),
         ('right', UMINUS),  # Unary minus operator, unary not
 
     )


### PR DESCRIPTION
Fix parsing query 
```sql
SELECT * FROM tbl WHERE Id % 10 = 0;
```
as:
```sql
SELECT * FROM tbl WHERE Id % (10 = 0);
```
fix: https://linear.app/mindsdb/issue/BE-428/sql-fix-modulo-precedence
