### PR TITLE
Optimize join tables from different databases

### DIFF
--- a/mindsdb_sql/planner/plan_join.py
+++ b/mindsdb_sql/planner/plan_join.py
@@ -481,6 +481,7 @@ class PlanJoinTablesQuery:
                 conditions.append(node)
             elif table2 is not None:
                 node.args = [arg1, arg2]
+                node = copy.deepcopy(node)
                 data_conditions.append(node)
 
         query_traversal(fetch_table.join_condition, _check_conditions)
@@ -501,12 +502,13 @@ class PlanJoinTablesQuery:
 
             # extract distinct values
             # remove alias
-            arg2 = Identifier(parts=[arg2.parts[-1]])
+            arg2.parts = arg2.parts[-1:]
             query2 = Select(targets=[arg2], distinct=True)
             subselect_step = SubSelectStep(query2, fetch_step.result)
             subselect_step = self.add_plan_step(subselect_step)
 
             condition.args[1] = Parameter(subselect_step.result)
+            condition.op = 'in'
             conditions.append(condition)
 
         return conditions

--- a/mindsdb_sql/planner/plan_join.py
+++ b/mindsdb_sql/planner/plan_join.py
@@ -145,7 +145,8 @@ class PlanJoinTablesQuery:
         return TableInfo(integration, table, aliases, conditions=[], sub_select=sub_select)
 
     def get_table_for_column(self, column: Identifier):
-
+        if not isinstance(column, Identifier):
+            return
         # to lowercase
         parts = tuple(map(str.lower, column.parts[:-1]))
         if parts in self.tables_idx:
@@ -381,7 +382,8 @@ class PlanJoinTablesQuery:
                 order_by = []
                 # all order column be from this table
                 for col in query_in.order_by:
-                    if self.get_table_for_column(col.field).table != item.table:
+                    table_info = self.get_table_for_column(col.field)
+                    if table_info is None or table_info.table != item.table:
                         order_by = False
                         break
                     col = copy.deepcopy(col)

--- a/tests/test_planner/test_join_predictor.py
+++ b/tests/test_planner/test_join_predictor.py
@@ -22,8 +22,6 @@ class TestPlanJoinPredictor:
         """
         query = parse_sql(sql)
 
-        query_step = parse_sql("select tab1.column1, pred.predicted")
-        query_step.from_table = Parameter(Result(2))
         expected_plan = QueryPlan(
             steps=[
                 FetchDataframeStep(integration='int',
@@ -75,7 +73,7 @@ class TestPlanJoinPredictor:
         plan = plan_query(query, integrations=['int'], predictor_namespace='mindsdb', predictor_metadata={'pred': {}})
 
         assert plan.steps == expected_plan.steps
-        
+
 
     def test_join_predictor_plan_limit(self):
 
@@ -116,7 +114,7 @@ class TestPlanJoinPredictor:
         plan = plan_query(query, integrations=['int'], predictor_namespace='mindsdb', predictor_metadata={'pred': {}})
 
         assert plan.steps == expected_plan.steps
-        
+
 
     # def test_join_predictor_error_when_filtering_on_predictions(self):
     #     """
@@ -673,15 +671,16 @@ class TestPredictorParams:
 
         sql = '''
                 select t2.x, m.id, (select a from int.tab0 where x=0) from int.tab1 t1
-                join int.tab2 t2 on t1.x = t2.x 
+                join int.tab2 t2 on t1.x = t2.a 
                 join mindsdb.pred m
                 where m.a=(select a from int.tab3 where x=3) 
                   and t2.x=(select a from int.tab4 where x=4)
                   and t1.b=1 and t2.b=2 and t1.a = t2.a
         '''
 
-        q_table2 = parse_sql('select * from tab2 as t2 where x=0 and b=2 ')
-        q_table2.where.args[0].args[1] = Parameter(Result(2))
+        q_table2 = parse_sql('select * from tab2 as t2 where x=0 and b=2 AND a IN 1')
+        q_table2.where.args[0].args[0].args[1] = Parameter(Result(2))
+        q_table2.where.args[1].args[1] = Parameter(Result(4))
 
         subquery = parse_sql("""
             select t2.x, m.id, x 
@@ -708,22 +707,23 @@ class TestPredictorParams:
                 # tables
                 FetchDataframeStep(integration='int',
                                    query=parse_sql('select * from tab1 as t1 where b=1')),
+                SubSelectStep(dataframe=Result(3), query=Select(targets=[Identifier('x')], distinct=True)),
                 FetchDataframeStep(integration='int', query=q_table2),
-                JoinStep(left=Result(3), right=Result(4),
+                JoinStep(left=Result(3), right=Result(5),
                          query=Join(left=Identifier('tab1'),
                                     right=Identifier('tab2'),
                                     join_type=JoinType.JOIN,
-                                    condition=BinaryOperation(op='=', args=[Identifier('t1.x'), Identifier('t2.x')])
+                                    condition=BinaryOperation(op='=', args=[Identifier('t1.x'), Identifier('t2.a')])
                         )
                 ),
                 # model
-                ApplyPredictorStep(namespace='mindsdb', dataframe=Result(5),
+                ApplyPredictorStep(namespace='mindsdb', dataframe=Result(6),
                                    predictor=Identifier('pred', alias=Identifier('m')), row_dict={'a': Result(1)}),
-                JoinStep(left=Result(5), right=Result(6),
+                JoinStep(left=Result(6), right=Result(7),
                          query=Join(left=Identifier('tab1'),
                                     right=Identifier('tab2'),
                                     join_type=JoinType.JOIN)),
-                QueryStep(subquery, from_table=Result(7)),
+                QueryStep(subquery, from_table=Result(8)),
             ],
         )
         plan = plan_query(query, integrations=['int'], predictor_namespace='mindsdb', predictor_metadata={'pred': {}})

--- a/tests/test_planner/test_join_tables.py
+++ b/tests/test_planner/test_join_tables.py
@@ -16,7 +16,7 @@ class TestPlanJoinTables:
         query = Select(targets=[Identifier('tab1.column1'), Identifier('tab2.column1'), Identifier('tab2.column2')],
                        from_table=Join(left=Identifier('int.tab1'),
                                        right=Identifier('int2.tab2'),
-                                       condition=BinaryOperation(op='=', args=[Identifier('tab1.column1'), Identifier('tab2.column1')]),
+                                       condition=BinaryOperation(op='>', args=[Identifier('tab1.column1'), Identifier('tab2.column1')]),
                                        join_type=JoinType.INNER_JOIN
                                        )
                 )
@@ -35,7 +35,7 @@ class TestPlanJoinTables:
                                       JoinStep(left=Result(0), right=Result(1),
                                                query=Join(left=Identifier('tab1'),
                                                           right=Identifier('tab2'),
-                                                          condition=BinaryOperation(op='=',
+                                                          condition=BinaryOperation(op='>',
                                                                                     args=[Identifier('tab1.column1'),
                                                                                           Identifier('tab2.column1')]),
                                                           join_type=JoinType.INNER_JOIN
@@ -45,13 +45,13 @@ class TestPlanJoinTables:
         )
 
         assert plan.steps == expected_plan.steps
-        
+
 
     def test_join_tables_where_plan(self):
         query = parse_sql('''
           SELECT tab1.column1, tab2.column1, tab2.column2 
           FROM int.tab1 
-          INNER JOIN int2.tab2 ON tab1.column1 = tab2.column1 
+          INNER JOIN int2.tab2 ON tab1.column1 > tab2.column1 
           WHERE ((tab1.column1 = 1) 
             AND (tab2.column1 = 0))
             AND (tab1.column3 = tab2.column3)
@@ -71,7 +71,7 @@ class TestPlanJoinTables:
                                       JoinStep(left=Result(0), right=Result(1),
                                                query=Join(left=Identifier('tab1'),
                                                           right=Identifier('tab2'),
-                                                          condition=BinaryOperation(op='=',
+                                                          condition=BinaryOperation(op='>',
                                                                                     args=[Identifier('tab1.column1'),
                                                                                           Identifier('tab2.column1')]),
                                                           join_type=JoinType.INNER_JOIN
@@ -90,7 +90,7 @@ class TestPlanJoinTables:
             Function('sum', args=[Identifier('tab2.column2')], alias=Identifier('total'))],
             from_table=Join(left=Identifier('int.tab1'),
                             right=Identifier('int2.tab2'),
-                            condition=BinaryOperation(op='=',
+                            condition=BinaryOperation(op='>',
                                                       args=[Identifier('tab1.column1'), Identifier('tab2.column1')]),
                             join_type=JoinType.INNER_JOIN
                             ),
@@ -117,7 +117,7 @@ class TestPlanJoinTables:
                                       JoinStep(left=Result(0), right=Result(1),
                                                query=Join(left=Identifier('tab1'),
                                                           right=Identifier('tab2'),
-                                                          condition=BinaryOperation(op='=',
+                                                          condition=BinaryOperation(op='>',
                                                                                     args=[Identifier('tab1.column1'),
                                                                                           Identifier('tab2.column1')]),
                                                           join_type=JoinType.INNER_JOIN
@@ -126,13 +126,13 @@ class TestPlanJoinTables:
                                   ],
                                   )
         assert plan.steps == expected_plan.steps
-        
+
 
     def test_join_tables_plan_limit_offset(self):
         query = Select(targets=[Identifier('tab1.column1'), Identifier('tab2.column1'), Identifier('tab2.column2')],
                        from_table=Join(left=Identifier('int.tab1'),
                                        right=Identifier('int2.tab2'),
-                                       condition=BinaryOperation(op='=', args=[Identifier('tab1.column1'), Identifier('tab2.column1')]),
+                                       condition=BinaryOperation(op='>', args=[Identifier('tab1.column1'), Identifier('tab2.column1')]),
                                        join_type=JoinType.INNER_JOIN
                                        ),
                        limit=Constant(10),
@@ -161,7 +161,7 @@ class TestPlanJoinTables:
                                       JoinStep(left=Result(0), right=Result(1),
                                                query=Join(left=Identifier('tab1'),
                                                           right=Identifier('tab2'),
-                                                          condition=BinaryOperation(op='=',
+                                                          condition=BinaryOperation(op='>',
                                                                                     args=[Identifier('tab1.column1'),
                                                                                           Identifier('tab2.column1')]),
                                                           join_type=JoinType.INNER_JOIN
@@ -171,13 +171,13 @@ class TestPlanJoinTables:
                                   )
 
         assert plan.steps == expected_plan.steps
-        
+
 
     def test_join_tables_plan_order_by(self):
         query = Select(targets=[Identifier('tab1.column1'), Identifier('tab2.column1'), Identifier('tab2.column2')],
                        from_table=Join(left=Identifier('int.tab1'),
                                        right=Identifier('int2.tab2'),
-                                       condition=BinaryOperation(op='=', args=[Identifier('tab1.column1'), Identifier('tab2.column1')]),
+                                       condition=BinaryOperation(op='>', args=[Identifier('tab1.column1'), Identifier('tab2.column1')]),
                                        join_type=JoinType.INNER_JOIN
                                        ),
                        limit=Constant(10),
@@ -203,7 +203,7 @@ class TestPlanJoinTables:
                                       JoinStep(left=Result(0), right=Result(1),
                                                query=Join(left=Identifier('tab1'),
                                                           right=Identifier('tab2'),
-                                                          condition=BinaryOperation(op='=',
+                                                          condition=BinaryOperation(op='>',
                                                                                     args=[Identifier('tab1.column1'),
                                                                                           Identifier('tab2.column1')]),
                                                           join_type=JoinType.INNER_JOIN
@@ -213,7 +213,7 @@ class TestPlanJoinTables:
                                   )
 
         assert plan.steps == expected_plan.steps
-        
+
 
     # This quiery should be sent to integration without raising exception
     # def test_join_tables_where_ambigous_column_error(self):
@@ -278,7 +278,7 @@ class TestPlanJoinTables:
 
         for i in range(len(plan.steps)):
             assert plan.steps[i] == expected_plan.steps[i]
-        
+
 
     def _disabled_test_join_tables_error_on_unspecified_table_in_condition(self):
         # disabled: identifier can be environment of system variable
@@ -328,7 +328,7 @@ class TestPlanJoinTables:
     def test_complex_join_tables(self):
         query = parse_sql('''
             select * from int1.tbl1 t1 
-            right join int2.tbl2 t2 on t1.id=t2.id
+            right join int2.tbl2 t2 on t1.id>t2.id
             join pred m
             left join tbl3 on tbl3.id=t1.id
             where t1.a=1 and t2.b=2 and 1=1
@@ -336,6 +336,9 @@ class TestPlanJoinTables:
 
         subquery = copy.deepcopy(query)
         subquery.from_table = None
+
+        q_table3 = parse_sql('select * from tbl3 where id in 0')
+        q_table3.where.args[1] = Parameter(Result(5))
 
         plan = plan_query(query, integrations=['int1', 'int2', 'proj'],  default_namespace='proj',
                           predictor_metadata=[{'name': 'pred', 'integration_name': 'proj'}])
@@ -349,7 +352,7 @@ class TestPlanJoinTables:
                        query=Join(left=Identifier('tab1'),
                                   right=Identifier('tab2'),
                                   condition=BinaryOperation(
-                                      op='=',
+                                      op='>',
                                       args=[Identifier('t1.id'),
                                             Identifier('t2.id')]),
                                   join_type=JoinType.RIGHT_JOIN)),
@@ -359,9 +362,10 @@ class TestPlanJoinTables:
                        query=Join(left=Identifier('tab1'),
                                     right=Identifier('tab2'),
                                     join_type=JoinType.JOIN)),
-              FetchDataframeStep(integration='proj', query=parse_sql('select * from tbl3')),
+              SubSelectStep(dataframe=Result(0), query=Select(targets=[Identifier('id')], distinct=True)),
+              FetchDataframeStep(integration='proj', query=q_table3),
               JoinStep(left=Result(4),
-                         right=Result(5),
+                         right=Result(6),
                          query=Join(left=Identifier('tab1'),
                                     right=Identifier('tab2'),
                                     condition=BinaryOperation(
@@ -369,7 +373,7 @@ class TestPlanJoinTables:
                                         args=[Identifier('tbl3.id'),
                                               Identifier('t1.id')]),
                                     join_type=JoinType.LEFT_JOIN)),
-              QueryStep(subquery, from_table=Result(6)),
+              QueryStep(subquery, from_table=Result(7)),
             ]
         )
 


### PR DESCRIPTION

For the query:
```sql
select * from table1 t1
join table2 t2 on t1.id=t2.id
```
After getting data from t1, it is extracting unique ids from this data and uses this query to get data from second table:
```sql
select * from table2 where id in (<ids from previous step>)
```

Fixes: https://linear.app/mindsdb/issue/BE-436/optimize-join