### PR TITLE
Cte support

### DIFF
--- a/mindsdb_sql/planner/plan_join.py
+++ b/mindsdb_sql/planner/plan_join.py
@@ -109,6 +109,7 @@ class PlanJoinTablesQuery:
             query2 = copy.deepcopy(query)
             query2.from_table = None
             query2.using = None
+            query2.cte = None
             sup_select = QueryStep(query2, from_table=join_step.result)
             self.planner.plan.add_step(sup_select)
             return sup_select
@@ -368,7 +369,8 @@ class PlanJoinTablesQuery:
         self.step_stack.append(step2)
 
     def process_table(self, item, query_in):
-        table = Identifier(parts=[item.integration] + item.table.parts)
+        table = copy.deepcopy(item.table)
+        table.parts.insert(0, item.integration)
         query2 = Select(from_table=table, targets=[Star()])
         # parts = tuple(map(str.lower, table_name.parts))
         conditions = item.conditions

--- a/mindsdb_sql/planner/plan_join.py
+++ b/mindsdb_sql/planner/plan_join.py
@@ -368,7 +368,8 @@ class PlanJoinTablesQuery:
         self.step_stack.append(step2)
 
     def process_table(self, item, query_in):
-        query2 = Select(from_table=item.table, targets=[Star()])
+        table = Identifier(parts=[item.integration] + item.table.parts)
+        query2 = Select(from_table=table, targets=[Star()])
         # parts = tuple(map(str.lower, table_name.parts))
         conditions = item.conditions
         if 'or' in self.query_context['binary_ops']:
@@ -404,8 +405,7 @@ class PlanJoinTablesQuery:
             else:
                 query2.where = cond
 
-        # step = self.planner.get_integration_select_step(query2)
-        step = FetchDataframeStep(integration=item.integration, query=query2)
+        step = self.planner.get_integration_select_step(query2)
         self.add_plan_step(step)
         self.step_stack.append(step)
 

--- a/mindsdb_sql/planner/query_prepare.py
+++ b/mindsdb_sql/planner/query_prepare.py
@@ -348,6 +348,8 @@ class PreparedStatementPlanner():
 
             elif column.name is not None:
                 # is Identifier
+                if isinstance(column.name, ast.Star):
+                    continue
                 col_name = column.name.upper()
                 if column.table is not None:
                     table = column.table

--- a/tests/test_planner/test_join_predictor.py
+++ b/tests/test_planner/test_join_predictor.py
@@ -62,7 +62,7 @@ class TestPlanJoinPredictor:
             steps=[
                 FetchDataframeStep(integration='int',
                                    query=Select(targets=[Star()],
-                                                from_table=Identifier('tab1', alias=Identifier('ta'))),
+                                                from_table=Identifier('tab1')),
                                    ),
                 ApplyPredictorStep(namespace='mindsdb', dataframe=Result(0), predictor=Identifier('pred', alias=Identifier('tb'))),
                 JoinStep(left=Result(0), right=Result(1),
@@ -144,14 +144,6 @@ class TestPlanJoinPredictor:
     #         plan_query(query, integrations=['postgres_90'], predictor_namespace='mindsdb', predictor_metadata={'hrp3': {}})
 
     def test_join_predictor_plan_complex_query(self):
-        query = Select(targets=[Identifier('tab.asset'), Identifier('tab.time'), Identifier('pred.predicted')],
-                       from_table=Join(left=Identifier('int.tab'),
-                                       right=Identifier('mindsdb.pred'),
-                                       join_type=JoinType.INNER_JOIN,
-                                       implicit=True),
-                       group_by=[Identifier('tab.asset')],
-                       having=BinaryOperation('=', args=[Identifier('tab.asset'), Constant('bitcoin')])
-                       )
 
         sql = """
             select t.asset, t.time, m.predicted
@@ -172,7 +164,7 @@ class TestPlanJoinPredictor:
             steps=[
                 FetchDataframeStep(
                     integration='int',
-                    query=parse_sql("select * from tab as t where col1 = 'x'")
+                    query=parse_sql("select * from tab where col1 = 'x'")
                 ),
                 ApplyPredictorStep(namespace='mindsdb', dataframe=Result(0), predictor=Identifier('pred', alias=Identifier('m'))),
                 JoinStep(left=Result(0), right=Result(1),
@@ -545,7 +537,7 @@ class TestPredictorVersion:
         expected_plan = QueryPlan(
             steps=[
                 FetchDataframeStep(integration='int',
-                                   query=parse_sql('select * from tab1 as a where x=1 and y=3')),
+                                   query=parse_sql('select * from tab1 where x=1 and y=3')),
                 ApplyPredictorStep(
                     namespace='proj', dataframe=Result(0),
                     predictor=Identifier('pred.1', alias=Identifier('p')),
@@ -616,7 +608,7 @@ class TestPredictorParams:
         expected_plan = QueryPlan(
             steps=[
                 FetchDataframeStep(integration='int',
-                                   query=parse_sql('select * from tab1 as t where b=2')),
+                                   query=parse_sql('select * from tab1 where b=2')),
                 ApplyPredictorStep(namespace='mindsdb', dataframe=Result(0),
                                    predictor=Identifier('pred', alias=Identifier('m')), row_dict={'a': 1}),
                 JoinStep(left=Result(0), right=Result(1),
@@ -649,9 +641,9 @@ class TestPredictorParams:
         expected_plan = QueryPlan(
             steps=[
                 FetchDataframeStep(integration='int',
-                                   query=parse_sql('select * from tab1 as t')),
+                                   query=parse_sql('select * from tab1')),
                 FetchDataframeStep(integration='int',
-                                   query=parse_sql('select * from tab2 as t2')),
+                                   query=parse_sql('select * from tab2')),
                 JoinStep(left=Result(0), right=Result(1),
                          query=Join(left=Identifier('tab1'),
                                     right=Identifier('tab2'),
@@ -680,7 +672,7 @@ class TestPredictorParams:
                   and t1.b=1 and t2.b=2 and t1.a = t2.a
         '''
 
-        q_table2 = parse_sql('select * from tab2 as t2 where x=0 and b=2 ')
+        q_table2 = parse_sql('select * from tab2 where x=0 and b=2 ')
         q_table2.where.args[0].args[1] = Parameter(Result(2))
 
         subquery = parse_sql("""
@@ -707,7 +699,7 @@ class TestPredictorParams:
                                    query=parse_sql('select a as a from tab4 where x=4')),
                 # tables
                 FetchDataframeStep(integration='int',
-                                   query=parse_sql('select * from tab1 as t1 where b=1')),
+                                   query=parse_sql('select * from tab1 where b=1')),
                 FetchDataframeStep(integration='int', query=q_table2),
                 JoinStep(left=Result(3), right=Result(4),
                          query=Join(left=Identifier('tab1'),
@@ -751,7 +743,7 @@ class TestPredictorParams:
         expected_plan = QueryPlan(
             steps=[
                 FetchDataframeStep(integration='int',
-                                   query=parse_sql('select * from tab1 as t')),
+                                   query=parse_sql('select * from tab1')),
                 ApplyPredictorStep(namespace='mindsdb', dataframe=Result(0),
                                    predictor=Identifier('pred', alias=Identifier('m')),
                                    row_dict={ 'a': 2 }, params={ 'param1': 'a', 'param3': 'c' }),
@@ -790,7 +782,7 @@ class TestPredictorParams:
         expected_plan = QueryPlan(
             steps=[
                 FetchDataframeStep(integration='int',
-                                   query=parse_sql('select * from tab1 as a')),
+                                   query=parse_sql('select * from tab1')),
                 ApplyPredictorStep(
                     namespace='proj', dataframe=Result(0),
                     predictor=Identifier('pred.1', alias=Identifier('p')),
@@ -829,7 +821,7 @@ class TestPredictorParams:
         expected_plan = QueryPlan(
             steps=[
                 FetchDataframeStep(integration='int',
-                                   query=parse_sql('select * from tab1 as a')),
+                                   query=parse_sql('select * from tab1')),
                 MapReduceStep(
                     values=Result(0),
                     step=[

--- a/tests/test_planner/test_join_tables.py
+++ b/tests/test_planner/test_join_tables.py
@@ -342,8 +342,8 @@ class TestPlanJoinTables:
 
         expected_plan = QueryPlan(
             steps=[
-              FetchDataframeStep(integration='int1', query=parse_sql('select * from tbl1 where a=1')),
-              FetchDataframeStep(integration='int2', query=parse_sql('select * from tbl2 where b=2')),
+              FetchDataframeStep(integration='int1', query=parse_sql('select * from tbl1 as t1 where a=1')),
+              FetchDataframeStep(integration='int2', query=parse_sql('select * from tbl2 as t2 where b=2')),
               JoinStep(left=Result(0),
                        right=Result(1),
                        query=Join(left=Identifier('tab1'),
@@ -389,7 +389,7 @@ class TestPlanJoinTables:
 
         expected_plan = QueryPlan(
             steps=[
-                FetchDataframeStep(integration='int1', query=parse_sql('select * from tbl1')),
+                FetchDataframeStep(integration='int1', query=parse_sql('select * from tbl1 as t1')),
                 FetchDataframeStep(integration='int2', query=parse_sql('select * from tbl3')),
                 ApplyPredictorStep(namespace='proj', dataframe=Result(1),
                                    predictor=Identifier('pred', alias=Identifier('m'))),

--- a/tests/test_planner/test_join_tables.py
+++ b/tests/test_planner/test_join_tables.py
@@ -342,8 +342,8 @@ class TestPlanJoinTables:
 
         expected_plan = QueryPlan(
             steps=[
-              FetchDataframeStep(integration='int1', query=parse_sql('select * from tbl1 as t1 where a=1')),
-              FetchDataframeStep(integration='int2', query=parse_sql('select * from tbl2 as t2 where b=2')),
+              FetchDataframeStep(integration='int1', query=parse_sql('select * from tbl1 where a=1')),
+              FetchDataframeStep(integration='int2', query=parse_sql('select * from tbl2 where b=2')),
               JoinStep(left=Result(0),
                        right=Result(1),
                        query=Join(left=Identifier('tab1'),
@@ -389,7 +389,7 @@ class TestPlanJoinTables:
 
         expected_plan = QueryPlan(
             steps=[
-                FetchDataframeStep(integration='int1', query=parse_sql('select * from tbl1 as t1')),
+                FetchDataframeStep(integration='int1', query=parse_sql('select * from tbl1')),
                 FetchDataframeStep(integration='int2', query=parse_sql('select * from tbl3')),
                 ApplyPredictorStep(namespace='proj', dataframe=Result(1),
                                    predictor=Identifier('pred', alias=Identifier('m'))),


### PR DESCRIPTION
Support query:
```sql
          with t1 as (
               select * from int1.tbl1
            )
            select t1.id, t2.* from t1 
            join int2.tbl2 t2 on t1.id>t2.id
```
fix: https://github.com/mindsdb/mindsdb/issues/4291